### PR TITLE
Fixes #14

### DIFF
--- a/lib/tty/prompt/reader.rb
+++ b/lib/tty/prompt/reader.rb
@@ -160,8 +160,6 @@ module TTY
 
       private
 
-      trap('SIGINT') { exit 130 }
-
       # Convert byte to unicode character
       #
       # @return [String]


### PR DESCRIPTION
Trap the interrupt and exiting causes REPLs, like pry and irb, to exit when the user hits ctrl+c.