### PR TITLE
Use input.readpartial(1) instead of sysread(1)

### DIFF
--- a/lib/tty/prompt/reader.rb
+++ b/lib/tty/prompt/reader.rb
@@ -90,7 +90,7 @@ module TTY
       #
       # @api public
       def read_char
-        chars = input.sysread(1)
+        chars = input.readpartial(1)
         while CSI.start_with?(chars) ||
               chars.start_with?(CSI) &&
               !(64..126).include?(chars.each_codepoint.to_a.last)


### PR DESCRIPTION
This may, or may not fix the issue #25 

I don't have access to a Windows box right now, but according to [docs](http://apidock.com/ruby/v1_9_3_392/IO/readpartial):

> readpartial is designed for streams such as pipe, socket, tty, etc. It blocks only when no data immediately available. 
> Note that readpartial behaves similar to sysread. The differences are:
> * If the byte buffer is not empty, read from the byte buffer instead of “sysread for buffered IO (IOError)”.
> * It doesn’t cause Errno::EWOULDBLOCK and Errno::EINTR. When readpartial meets EWOULDBLOCK and EINTR by read system call, readpartial retry the system call.

(looks like your travis config is messed up)
