### PR TITLE
Fix: question input encoding problem.

### DIFF
--- a/lib/tty/prompt/question.rb
+++ b/lib/tty/prompt/question.rb
@@ -45,6 +45,7 @@ module TTY
         @messages   = Utils.deep_copy(options.fetch(:messages) { { } })
         @done       = false
         @input      = nil
+        @input_encoding = options.fetch(:input_encoding) { UndefinedSetting }
 
         @evaluator = Evaluator.new(self)
 
@@ -135,7 +136,34 @@ module TTY
         if Utils.blank?(@input)
           @input = default? ? default : nil
         end
+
+        if @input && encode_input?
+          if @input.is_a? String
+            @input = encode_input(@input)
+          elsif @input.is_a? Array
+            @input = @input.map { |input| encode_input(input) }
+          end
+        end
+
         @evaluator.(@input)
+      end
+
+      # Encod input
+      #
+      # @return [Boolean]
+      #
+      # @api private
+      def encode_input(line)
+        line.codepoints.to_a.pack('C*').force_encoding(@input_encoding)
+      end
+
+      # Check if input needs encoding
+      #
+      # @return [Boolean]
+      #
+      # @api private
+      def encode_input?
+        @input_encoding != UndefinedSetting
       end
 
       # Process input

--- a/spec/unit/ask_spec.rb
+++ b/spec/unit/ask_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe TTY::Prompt, '#ask' do
     ].join)
   end
 
+  it "asks a question with a input encoding" do
+    prompt.input << "한글"
+    prompt.input.rewind
+    answer = prompt.ask("UTF-8 charater?")
+    expect(answer).not_to eql("한글")
+
+    prompt.input << "한글"
+    prompt.input.rewind
+    answer = prompt.ask("Need encoding?", input_encoding: "utf-8")
+    expect(answer).not_to eql("한글")
+  end
+
   it 'asks a question with block' do
     prompt.input << ''
     prompt.input.rewind


### PR DESCRIPTION
When I get input from question with utf-8, It breaks.
For example

```ruby
TTY::Prompt.new.ask("Ask?")

Ask? 한글

=> "í\u0095\u009Cê¸\u0080"
```

I fix this problem.