### PR TITLE
add echo support to multilist

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Or install it yourself as:
   * [2.6 menu](#26-menu)
     * [2.6.1 select](#261-select)
     * [2.6.2 multi_select](#262-multi_select)
+    * [2.6.2.1 echo](#2621-echo)
     * [2.6.3 enum_select](#263-enum_select)
   * [2.7 expand](#27-expand)
   * [2.8 collect](#28-collect)
@@ -678,6 +679,23 @@ prompt.multi_select("Choose your letter?", letters, per_page: 4)
 #   ⬡ C
 #   ⬡ D
 # (Move up or down to reveal more choices)
+```
+
+### 2.6.2.1 echo
+
+To control whether the selected items are shown on the question
+header use the :echo option:
+
+```ruby
+choices = %w(vodka beer wine whisky bourbon)
+prompt.multi_select("Select drinks?", choices, echo: false)
+# =>
+# Select drinks?
+#   ⬡ vodka
+#   ⬢ 2) beer
+#   ⬡ 3) wine
+#   ⬡ 4) whisky
+# ‣ ⬢ 5) bourbon
 ```
 
 ### 2.6.3 enum_select

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -22,6 +22,7 @@ module TTY
         @selected = []
         @help    = options[:help]
         @default = Array(options[:default])
+        @echo = options.fetch(:echo, true)
       end
 
       # Callback fired when space key is pressed
@@ -61,9 +62,9 @@ module TTY
       # @api private
       def render_header
         instructions = @prompt.decorate(help, :bright_black)
-        if @done
+        if @done && @echo
           @prompt.decorate(selected_names, @active_color)
-        elsif @selected.size.nonzero?
+        elsif @selected.size.nonzero? && @echo
           selected_names + (@first_render ? " #{instructions}" : '')
         elsif @first_render
           instructions

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -46,6 +46,31 @@ RSpec.describe TTY::Prompt do
     ].join)
   end
 
+  it "selects item when space pressed but doesn't echo item if echo: false" do
+    prompt = TTY::TestPrompt.new
+    choices = %w(vodka beer wine whisky bourbon)
+    prompt.input << " \r"
+    prompt.input.rewind
+    expect(prompt.multi_select("Select drinks?", choices, echo: false)). to eq(['vodka'])
+    expect(prompt.output.string).to eq([
+      "\e[?25lSelect drinks? \e[90m(Use arrow keys, press Space to select and Enter to finish)\e[0m\n",
+      "#{symbols[:pointer]} #{symbols[:radio_off]} vodka\n",
+      "  #{symbols[:radio_off]} beer\n",
+      "  #{symbols[:radio_off]} wine\n",
+      "  #{symbols[:radio_off]} whisky\n",
+      "  #{symbols[:radio_off]} bourbon",
+      "\e[2K\e[1G\e[1A" * 5, "\e[2K\e[1G",
+      "Select drinks? \n",
+      "‣ \e[32m#{symbols[:radio_on]}\e[0m vodka\n",
+      "  #{symbols[:radio_off]} beer\n",
+      "  #{symbols[:radio_off]} wine\n",
+      "  #{symbols[:radio_off]} whisky\n",
+      "  #{symbols[:radio_off]} bourbon",
+      "\e[2K\e[1G\e[1A" * 5, "\e[2K\e[1G",
+      "Select drinks? \n\e[?25h"
+      ].join)
+  end
+
   it "sets choice custom values" do
     prompt = TTY::TestPrompt.new
     choices = {vodka: 1, beer: 2, wine: 3, whisky: 4, bourbon: 5}

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe TTY::Prompt do
       "  #{symbols[:radio_off]} bourbon",
       "\e[2K\e[1G\e[1A" * 5, "\e[2K\e[1G",
       "Select drinks? \n\e[?25h"
-      ].join)
+    ].join)
   end
 
   it "sets choice custom values" do


### PR DESCRIPTION
Given very long descriptive names for a multi select menu, the echoing of the selections gets awkward fast.  This adds `echo: false` option support to do MultiList.  The selections won't be echoed in the header, but the radio button will still fill in.