### PR TITLE
Add spec to detect Forwardable error on Ruby 2.4

### DIFF
--- a/spec/unit/select_spec.rb
+++ b/spec/unit/select_spec.rb
@@ -22,6 +22,16 @@ RSpec.describe TTY::Prompt, '#select' do
     ].join)
   end
 
+  it "allows navigation using events without errors" do
+    choices = %w(Large Medium Small)
+    prompt.input << "j" << "\r"
+    prompt.input.rewind
+    prompt.on(:keypress) do |event|
+      prompt.publish(:keydown) if event.value == "j"
+    end
+    expect { prompt.select('What size?', choices) }.not_to output.to_stderr
+  end
+
   it "sets choice name and value" do
     choices = {large: 1, medium: 2, small: 3}
     prompt.input << " "


### PR DESCRIPTION
Attached a PR that seems to catch the error message in Ruby 2.4 `Forwardable`:

```sh
projects/tty-prompt [2m|master:1↑] (1) chruby 2.3 && bundle exec rspec --no-profile spec/unit/select_spec.rb:25
Run options: include {:locations=>{"./spec/unit/select_spec.rb"=>[25]}}

Randomized with seed 28836

TTY::Prompt#select
  allows navigation using events without errors

Finished in 0.05101 seconds (files took 0.85909 seconds to load)
1 example, 0 failures

Randomized with seed 28836

projects/tty-prompt [4m|master:1↑] (1) chruby 2.4 && bundle exec rspec --no-profile spec/unit/select_spec.rb:25
Run options: include {:locations=>{"./spec/unit/select_spec.rb"=>[25]}}

Randomized with seed 64125

TTY::Prompt#select
  allows navigation using events without errors (FAILED - 1)

Failures:

  1) TTY::Prompt#select allows navigation using events without errors
     Failure/Error: expect{ prompt.select('What size?', choices) }.not_to output.to_stderr
       expected block to not output to stderr, but output "/cygdrive/c/Users/q284114/projects/tty-prompt/spec/unit/select_spec.rb:30:in `block (3 levels) in <t...-2.4.0/lib/ruby/2.4.0/forwardable.rb:156 forwarding to private method TTY::Prompt::Reader#publish\n"
     # ./spec/unit/select_spec.rb:32:in `block (2 levels) in <top (required)>'

Finished in 0.06701 seconds (files took 0.48705 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/unit/select_spec.rb:25 # TTY::Prompt#select allows navigation using events without errors

Randomized with seed 64125
```

See issue #35.