### PR TITLE
Fixed issue with default parameter on yes/no

### DIFF
--- a/lib/tty/prompt/confirm_question.rb
+++ b/lib/tty/prompt/confirm_question.rb
@@ -108,29 +108,17 @@ module TTY
       end
 
       def create_default_labels
-        if is?(:yes)
-          @suffix   = default? ? 'Y/n' : 'y/N'
-          @positive = default? ? 'Yes' : 'yes'
-          @negative = default? ? 'no' : 'No'
-        else
-          @suffix   = default? ? 'y/N' : 'Y/n'
-          @positive = default? ? 'Yes' : 'yes'
-          @negative = default? ? 'No'  : 'no'
+          @suffix   = @default ? 'Y/n' : 'y/N'
+          @positive = @default ? 'Yes' : 'yes'
+          @negative = @default ? 'no' : 'No'
         end
-      end
 
       # @api private
       def create_suffix
         result = ''
-        if is?(:yes)
-          result << "#{default? ? @positive.capitalize : @positive.downcase}"
+          result << "#{@default ? @positive.capitalize : @positive.downcase}"
           result << '/'
-          result << "#{default? ? @negative.downcase : @negative.capitalize}"
-        else
-          result << "#{default? ? @positive.downcase : @positive.capitalize}"
-          result << '/'
-          result << "#{default? ? @negative.capitalize : @negative.downcase}"
-        end
+          result << "#{@default ? @negative.downcase : @negative.capitalize}"
       end
 
       # Create custom conversion

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       prompt.input.rewind
       expect(prompt.yes?("Are you a human?", default: false)).to eq(false)
       expect(prompt.output.string).to eq([
-        "Are you a human? \e[90m(Y/n)\e[0m ",
+        "Are you a human? \e[90m(y/N)\e[0m ",
         "\e[1A\e[2K\e[1G",
-        "Are you a human? \e[32mno\e[0m\n"
+        "Are you a human? \e[32mNo\e[0m\n"
       ].join)
     end
 
@@ -129,7 +129,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       expect(prompt.output.string).to eq([
         "Are you a human? \e[90m(y/N)\e[0m ",
         "\e[1A\e[2K\e[1G",
-        "Are you a human? \e[32mYes\e[0m\n"
+        "Are you a human? \e[32myes\e[0m\n"
       ].join)
     end
 
@@ -149,7 +149,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       prompt.input.rewind
       expect(prompt.no?("Are you a human?", default: true)).to eq(false)
       expect(prompt.output.string).to eq([
-        "Are you a human? \e[90m(y/N)\e[0m ",
+        "Are you a human? \e[90m(Y/n)\e[0m ",
         "\e[1A\e[2K\e[1G",
         "Are you a human? \e[32mYes\e[0m\n"
       ].join)


### PR DESCRIPTION
`default?` only returns whether or not the parameter was set, it does not return its value.
Fixes #47.