### PR TITLE
Enforce that per_page is >= 1

### DIFF
--- a/lib/tty/prompt/enum_paginator.rb
+++ b/lib/tty/prompt/enum_paginator.rb
@@ -13,6 +13,8 @@ module TTY
         default_size = (list.size <= DEFAULT_PAGE_SIZE ? list.size : DEFAULT_PAGE_SIZE)
         @per_page = @per_page || per_page || default_size
 
+        raise ArgumentError, 'per_page must be > 0' if @per_page < 1
+
         # Don't paginate short lists
         if list.size <= @per_page
           @lower_index = 0

--- a/lib/tty/prompt/paginator.rb
+++ b/lib/tty/prompt/paginator.rb
@@ -43,6 +43,8 @@ module TTY
         @lower_index ||= current_index
         @upper_index ||= max_index
 
+        raise ArgumentError, 'per_page must be > 0' if @per_page < 1
+
         # Don't paginate short lists
         if list.size <= @per_page
           @lower_index = 0


### PR DESCRIPTION
Without this check, weird and buggy behavior occurs if the user sets `per_page: 0` or `per_page: -1`.