### PR TITLE
Make wrapping in list optional

### DIFF
--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -41,6 +41,7 @@ module TTY
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
         @marker       = options.fetch(:marker) { symbols[:pointer] }
+        @wraparound   = options.fetch(:wraparound) { true }
         @help         = options[:help]
         @first_render = true
         @done         = false
@@ -178,11 +179,23 @@ module TTY
       end
 
       def keyup(*)
-        @active = (@active == 1) ? @choices.length : @active - 1
+        if @active == 1
+          if @wraparound
+            @active = @choices.length
+          end
+        else
+          @active -= 1
+        end
       end
 
       def keydown(*)
-        @active = (@active == @choices.length) ? 1 : @active + 1
+        if @active == @choices.length
+          if @wraparound
+            @active = 1
+          end
+        else
+          @active += 1
+        end
       end
       alias keytab keydown
 


### PR DESCRIPTION
Currently the wrapping behaviour in `#select` is hard-coded; when reaching the top of the list and receiving a `keyup` event, the selection jumps to the last item and vice versa when reaching the end of the list and pressing `keydown`.

For some lists (e.g. chronologically sorted ones), this behaviour does not make sense; it would be better to stay at the ends of the list and ignore keystrokes which would send you beyond.

This PR introduces an option `wraparound`, which defaults to true.