### PR TITLE
Make cycling in list optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,17 @@ end
 # ‣ Jax
 ```
 
+You can navigate the choices using the arrow keys or define your own keymappings (see [keyboard events](#212-keyboard-events). When reaching the top/bottom of the list, the selection does not cycle around by default. If you wish to enable cycling, you can pass `cycle: true` to `select` and `mutli_select`:
+
+```ruby
+prompt.select("Choose your destiny?", %w(Scorpion Kano Jax), cycle: true)
+# =>
+# Choose your destiny? (Use arrow keys, press Enter to select)
+# ‣ Scorpion
+#   Kano
+#   Jax
+```
+
 For ordered choices set `enum` to any delimiter String. In that way, you can use arrows keys and numbers (0-9) to select the item.
 
 ```ruby
@@ -702,6 +713,12 @@ And when you press enter you will see the following selected:
 ```ruby
 # Select drinks? beer, bourbon
 # => [{score: 20}, {score: 50}]
+```
+
+Also like, `select`, the method takes an option `cycle` (which defaults to `false`), which lets you configure whether the selection should cycle around when reaching the top/bottom of the list when navigating:
+
+```ruby
+prompt.multi_select("Select drinks?", %w(vodka beer wine), cycle: true)
 ```
 
 You can configure help message and/or marker like so

--- a/examples/ask.rb
+++ b/examples/ask.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/collect.rb
+++ b/examples/collect.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new(prefix: '[?] ')
 

--- a/examples/echo.rb
+++ b/examples/echo.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/enum.rb
+++ b/examples/enum.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/enum_paged.rb
+++ b/examples/enum_paged.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/enum_select.rb
+++ b/examples/enum_select.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 choices = %w(/bin/nano /usr/bin/vim.basic /usr/bin/vim.tiny)

--- a/examples/expand.rb
+++ b/examples/expand.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 choices = [{
   key: 'y',

--- a/examples/in.rb
+++ b/examples/in.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/inputs.rb
+++ b/examples/inputs.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/key_events.rb
+++ b/examples/key_events.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt::new(interrupt: :exit)
 

--- a/examples/keypress.rb
+++ b/examples/keypress.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt::new
 

--- a/examples/mask.rb
+++ b/examples/mask.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 require 'pastel'
 
 prompt = TTY::Prompt.new

--- a/examples/multi_select.rb
+++ b/examples/multi_select.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/multi_select_paged.rb
+++ b/examples/multi_select_paged.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/multiline.rb
+++ b/examples/multiline.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt::new
 

--- a/examples/pause.rb
+++ b/examples/pause.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt::new
 

--- a/examples/select.rb
+++ b/examples/select.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/select_paginated.rb
+++ b/examples/select_paginated.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/slider.rb
+++ b/examples/slider.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 prompt.slider("What size?", min: 0, max: 40, step: 1)

--- a/examples/validation.rb
+++ b/examples/validation.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/examples/yes_no.rb
+++ b/examples/yes_no.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-require 'tty-prompt'
+require_relative "../lib/tty-prompt"
 
 prompt = TTY::Prompt.new
 

--- a/lib/tty/prompt/enum_list.rb
+++ b/lib/tty/prompt/enum_list.rb
@@ -24,6 +24,7 @@ module TTY
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color)   { @prompt.help_color }
         @error_color  = options.fetch(:error_color)  { @prompt.error_color }
+        @cycle        = options.fetch(:cycle) { false }
         @input        = nil
         @done         = false
         @first_render = true
@@ -140,7 +141,7 @@ module TTY
         if (@page_active + page_size) <= @choices.size
           @page_active += page_size
         else
-          @page_active = 1
+          @page_active = 1 if @cycle
         end
       end
       alias keytab keyright
@@ -149,7 +150,7 @@ module TTY
         if (@page_active - page_size) >= 0
           @page_active -= page_size
         else
-          @page_active = @choices.size - 1
+          @page_active = @choices.size - 1 if @cycle
         end
       end
 

--- a/lib/tty/prompt/enum_list.rb
+++ b/lib/tty/prompt/enum_list.rb
@@ -140,8 +140,8 @@ module TTY
       def keyright(*)
         if (@page_active + page_size) <= @choices.size
           @page_active += page_size
-        else
-          @page_active = 1 if @cycle
+        elsif @cycle
+          @page_active = 1
         end
       end
       alias keytab keyright
@@ -149,8 +149,8 @@ module TTY
       def keyleft(*)
         if (@page_active - page_size) >= 0
           @page_active -= page_size
-        else
-          @page_active = @choices.size - 1 if @cycle
+        elsif @cycle
+          @page_active = @choices.size - 1
         end
       end
 

--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -41,6 +41,7 @@ module TTY
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
         @marker       = options.fetch(:marker) { symbols[:pointer] }
+        @wraparound   = options.fetch(:wraparound) { true }
         @help         = options[:help]
         @first_render = true
         @done         = false
@@ -178,11 +179,23 @@ module TTY
       end
 
       def keyup(*)
-        @active = (@active == 1) ? @choices.length : @active - 1
+        if @active == 1
+          if @wraparound
+            @active = @choices.length
+          end
+        else
+          @active -= 1
+        end
       end
 
       def keydown(*)
-        @active = (@active == @choices.length) ? 1 : @active + 1
+        if @active == @choices.length
+          if @wraparound
+            @active = 1
+          end
+        else
+          @active += 1
+        end
       end
       alias keytab keydown
 

--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -41,7 +41,7 @@ module TTY
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
         @marker       = options.fetch(:marker) { symbols[:pointer] }
-        @wraparound   = options.fetch(:wraparound) { true }
+        @cycle        = options.fetch(:cycle) { false }
         @help         = options[:help]
         @first_render = true
         @done         = false
@@ -180,9 +180,7 @@ module TTY
 
       def keyup(*)
         if @active == 1
-          if @wraparound
-            @active = @choices.length
-          end
+          @active = @choices.length if @cycle
         else
           @active -= 1
         end
@@ -190,9 +188,7 @@ module TTY
 
       def keydown(*)
         if @active == @choices.length
-          if @wraparound
-            @active = 1
-          end
+          @active = 1 if @cycle
         else
           @active += 1
         end

--- a/spec/unit/enum_select_spec.rb
+++ b/spec/unit/enum_select_spec.rb
@@ -307,4 +307,90 @@ RSpec.describe TTY::Prompt do
       "What letter? \e[32mD\e[0m\n"
     ].join)
   end
+
+  it "doesn't cycle around by default" do
+    prompt = TTY::TestPrompt.new
+    choices = %w(A B C D E F)
+    prompt.input << "\t" << "\t" << "\n"
+    prompt.input.rewind
+    value = prompt.enum_select("What letter?") do |menu|
+              menu.default 1
+              menu.per_page 3
+              menu.choices choices
+            end
+    expect(value).to eq('A')
+    expect(prompt.output.string).to eq([
+      "What letter? \n",
+      "\e[32m  1) A\e[0m\n",
+      "  2) B\n",
+      "  3) C\n",
+      "  Choose 1-6 [1]: ",
+      "\n\e[90m(Press tab/right or left to reveal more choices)\e[0m",
+      "\e[A\e[1G\e[18C",
+      "\e[2K\e[1G\e[1A" * 4,
+      "\e[2K\e[1G\e[J",
+      "What letter? \n",
+      "  4) D\n",
+      "  5) E\n",
+      "  6) F\n",
+      "  Choose 1-6 [1]: ",
+      "\n\e[90m(Press tab/right or left to reveal more choices)\e[0m",
+      "\e[A\e[1G\e[18C",
+      "\e[2K\e[1G\e[1A" * 4,
+      "\e[2K\e[1G\e[J",
+      "What letter? \n",
+      "  4) D\n",
+      "  5) E\n",
+      "  6) F\n",
+      "  Choose 1-6 [1]: ",
+      "\n\e[90m(Press tab/right or left to reveal more choices)\e[0m",
+      "\e[A\e[1G\e[18C",
+      "\e[2K\e[1G\e[1A" * 4,
+      "\e[2K\e[1G\e[J",
+      "What letter? \e[32mA\e[0m\n"
+    ].join)
+  end
+
+  it "cycles around when configured to do so" do
+    prompt = TTY::TestPrompt.new
+    choices = %w(A B C D E F)
+    prompt.input << "\t" << "\t" << "\n"
+    prompt.input.rewind
+    value = prompt.enum_select("What letter?", cycle: true) do |menu|
+              menu.default 1
+              menu.per_page 3
+              menu.choices choices
+            end
+    expect(value).to eq('A')
+    expect(prompt.output.string).to eq([
+      "What letter? \n",
+      "\e[32m  1) A\e[0m\n",
+      "  2) B\n",
+      "  3) C\n",
+      "  Choose 1-6 [1]: ",
+      "\n\e[90m(Press tab/right or left to reveal more choices)\e[0m",
+      "\e[A\e[1G\e[18C",
+      "\e[2K\e[1G\e[1A" * 4,
+      "\e[2K\e[1G\e[J",
+      "What letter? \n",
+      "  4) D\n",
+      "  5) E\n",
+      "  6) F\n",
+      "  Choose 1-6 [1]: ",
+      "\n\e[90m(Press tab/right or left to reveal more choices)\e[0m",
+      "\e[A\e[1G\e[18C",
+      "\e[2K\e[1G\e[1A" * 4,
+      "\e[2K\e[1G\e[J",
+      "What letter? \n",
+      "\e[32m  1) A\e[0m\n",
+      "  2) B\n",
+      "  3) C\n",
+      "  Choose 1-6 [1]: ",
+      "\n\e[90m(Press tab/right or left to reveal more choices)\e[0m",
+      "\e[A\e[1G\e[18C",
+      "\e[2K\e[1G\e[1A" * 4,
+      "\e[2K\e[1G\e[J",
+      "What letter? \e[32mA\e[0m\n"
+    ].join)
+  end
 end

--- a/spec/unit/enum_select_spec.rb
+++ b/spec/unit/enum_select_spec.rb
@@ -318,7 +318,7 @@ RSpec.describe TTY::Prompt do
               menu.per_page 3
               menu.choices choices
             end
-    expect(value).to eq('A')
+    expect(value).to eq("A")
     expect(prompt.output.string).to eq([
       "What letter? \n",
       "\e[32m  1) A\e[0m\n",
@@ -361,7 +361,7 @@ RSpec.describe TTY::Prompt do
               menu.per_page 3
               menu.choices choices
             end
-    expect(value).to eq('A')
+    expect(value).to eq("A")
     expect(prompt.output.string).to eq([
       "What letter? \n",
       "\e[32m  1) A\e[0m\n",

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -6,15 +6,19 @@ RSpec.describe TTY::Prompt do
   def output_helper(prompt, choices, active, selected,
                     hint: "Use arrow keys, press Space to select and Enter to finish",
                     init: false)
-    if init
-      out = "\e[?25l#{prompt} \e[90m(#{hint})\e[0m\n"
-    else
-      out = "#{prompt} #{selected.join(", ")}\n"
-    end
-    out << choices.map do |c|
-      prefix =  (c == active) ? "#{symbols[:pointer]} " : "  "
-      prefix += (selected.include?(c)) ? "\e[32m#{symbols[:radio_on]}\e[0m" : "#{symbols[:radio_off]}"
-      "#{prefix} #{c}"
+    out = if init
+            "\e[?25l#{prompt} \e[90m(#{hint})\e[0m\n"
+          else
+            "#{prompt} #{selected.join(', ')}\n"
+          end
+    out << choices.map do |choice|
+      prefix = choice == active ? "#{symbols[:pointer]} " : "  "
+      prefix += if selected.include? choice
+                  "\e[32m#{symbols[:radio_on]}\e[0m "
+                else
+                  "#{symbols[:radio_off]} "
+                end
+      prefix + choice
     end.join("\n")
     out << "\e[2K\e[1G\e[1A" * choices.count
     out << "\e[2K\e[1G"
@@ -370,5 +374,4 @@ RSpec.describe TTY::Prompt do
       "What letter? \e[32mA\e[0m\n\e[?25h"
     )
   end
-
 end

--- a/spec/unit/select_spec.rb
+++ b/spec/unit/select_spec.rb
@@ -6,6 +6,19 @@ RSpec.describe TTY::Prompt, '#select' do
 
   let(:symbols) { TTY::Prompt::Symbols.symbols }
 
+  def output_helper(prompt, choices, active,
+                    hint: "Use arrow keys, press Enter to select",
+                    init: false)
+    out = ""
+    out << (init ? "\e[?25l#{prompt} \e[90m(#{hint})\e[0m\n" : "#{prompt} \n")
+    out << choices.map do |c|
+      (c == active ? "\e[32m#{symbols[:pointer]} #{c}\e[0m" : "  #{c}")
+    end.join("\n")
+    out << "\e[2K\e[1G\e[1A" * choices.count
+    out << "\e[2K\e[1G"
+    out
+  end
+
   it "selects by default first option" do
     choices = %w(Large Medium Small)
     prompt.input << "\r"
@@ -295,7 +308,7 @@ RSpec.describe TTY::Prompt, '#select' do
     choices = %w(A B C D E F G H)
     prompt.input << "\r"
     prompt.input.rewind
-    value = prompt.select('What letter?') do |menu|
+    value = prompt.select("What letter?") do |menu|
               menu.per_page 3
               menu.page_help '(Wiggle thy finger up or down to see more)'
               menu.default 4
@@ -313,6 +326,40 @@ RSpec.describe TTY::Prompt, '#select' do
       "\e[2K\e[1G",
       "What letter? \e[32mD\e[0m\n\e[?25h",
     ].join)
+  end
+
+  it "doesn't cycle by default" do
+    prompt = TTY::TestPrompt.new
+    choices = %w(A B C)
+    prompt.on(:keypress) { |e| prompt.trigger(:keydown) if e.value == "j" }
+    prompt.input << "j" << "j" << "j" << "\r"
+    prompt.input.rewind
+    value = prompt.select("What letter?", choices)
+    expect(value).to eq("C")
+    expect(prompt.output.string).to eq(
+      output_helper("What letter?", choices, "A", init: true) +
+      output_helper("What letter?", choices, "B") +
+      output_helper("What letter?", choices, "C") +
+      output_helper("What letter?", choices, "C") +
+      "What letter? \e[32mC\e[0m\n\e[?25h"
+    )
+  end
+
+  it "cycles around when configured to do so" do
+    prompt = TTY::TestPrompt.new
+    choices = %w(A B C)
+    prompt.on(:keypress) { |e| prompt.trigger(:keydown) if e.value == "j" }
+    prompt.input << "j" << "j" << "j" << "\r"
+    prompt.input.rewind
+    value = prompt.select("What letter?", choices, cycle: true)
+    expect(value).to eq("A")
+    expect(prompt.output.string).to eq(
+      output_helper("What letter?", choices, "A", init: true) +
+      output_helper("What letter?", choices, "B") +
+      output_helper("What letter?", choices, "C") +
+      output_helper("What letter?", choices, "A") +
+      "What letter? \e[32mA\e[0m\n\e[?25h"
+    )
   end
 
   it "verifies default index format" do


### PR DESCRIPTION
Currently the wrapping behaviour in `#select` is hard-coded; when reaching the top of the list and receiving a `keyup` event, the selection jumps to the last item and vice versa when reaching the end of the list and pressing `keydown`.

For some lists (e.g. chronologically sorted ones), this behaviour does not make sense; it would be better to stay at the ends of the list and ignore keystrokes which would send you beyond.

This PR introduces an option `wraparound`, which defaults to true.