### PR TITLE
Add lists filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Or install it yourself as:
     * [2.6.1 select](#261-select)
     * [2.6.2 multi_select](#262-multi_select)
     * [2.6.2.1 echo](#2621-echo)
+    * [2.6.2.2 filter](#2622-filter)
     * [2.6.3 enum_select](#263-enum_select)
   * [2.7 expand](#27-expand)
   * [2.8 collect](#28-collect)
@@ -777,6 +778,36 @@ prompt.multi_select("Select drinks?", choices, echo: false)
 #   ⬡ 4) whisky
 # ‣ ⬢ 5) bourbon
 ```
+
+### 2.6.2.2 filter
+
+To activate dynamic list filtering on letter/number typing, use the :filter option:
+
+```ruby
+choices = %w(vodka beer wine whisky bourbon)
+prompt.multi_select("Select drinks?", choices, filter: true)
+# =>
+# Select drinks? (Use arrow keys, press Space to select and Enter to finish, and letter keys to filter)
+# ‣ ⬡ vodka
+#   ⬡ beer
+#   ⬡ wine
+#   ⬡ whisky
+#   ⬡ bourbon
+```
+
+After the user presses "w":
+
+```
+# Select drinks? (Filter: "w")
+# ‣ ⬡ wine
+#   ⬡ whisky
+```
+
+Filter characters can be deleted partially or entirely via, respectively, Backspace and Canc.
+
+If the user changes or deletes a filter, the choices previously selected remain selected.
+
+The `filter` option is not compatible with `enum`.
 
 ### 2.6.3 enum_select
 

--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -1,5 +1,7 @@
 # encoding: utf-8
 
+require "English"
+
 require_relative 'choices'
 require_relative 'paginator'
 require_relative 'symbols'
@@ -13,9 +15,12 @@ module TTY
     class List
       include Symbols
 
-      HELP = '(Use arrow%s keys, press Enter to select)'
+      HELP = '(Use arrow%s keys, press Enter to select%s)'
 
       PAGE_HELP = '(Move up or down to reveal more choices)'
+
+      # Allowed keys for filter, along with backspace and canc.
+      FILTER_KEYS_MATCHER = /\A\w\Z/
 
       # Create instance of TTY::Prompt::List menu.
       #
@@ -32,22 +37,25 @@ module TTY
       #
       # @api public
       def initialize(prompt, options = {})
-        @prompt       = prompt
-        @prefix       = options.fetch(:prefix) { @prompt.prefix }
-        @enum         = options.fetch(:enum) { nil }
-        @default      = Array[options.fetch(:default) { 1 }]
-        @active       = @default.first
-        @choices      = Choices.new
-        @active_color = options.fetch(:active_color) { @prompt.active_color }
-        @help_color   = options.fetch(:help_color) { @prompt.help_color }
-        @marker       = options.fetch(:marker) { symbols[:pointer] }
-        @cycle        = options.fetch(:cycle) { false }
-        @help         = options[:help]
-        @first_render = true
-        @done         = false
-        @per_page     = options[:per_page]
-        @page_help    = options[:page_help] || PAGE_HELP
-        @paginator    = Paginator.new
+        check_options_consistency(options)
+
+        @prompt         = prompt
+        @prefix         = options.fetch(:prefix) { @prompt.prefix }
+        @enum           = options.fetch(:enum) { nil }
+        @default        = Array[options.fetch(:default) { 1 }]
+        @active         = @default.first
+        @choices        = Choices.new
+        @active_color   = options.fetch(:active_color) { @prompt.active_color }
+        @help_color     = options.fetch(:help_color) { @prompt.help_color }
+        @marker         = options.fetch(:marker) { symbols[:pointer] }
+        @cycle          = options.fetch(:cycle) { false }
+        @help           = options[:help]
+        @first_render   = true
+        @done           = false
+        @per_page       = options[:per_page]
+        @page_help      = options[:page_help] || PAGE_HELP
+        @paginator      = Paginator.new
+        @choices_filter = options.fetch(:filter) { false } ? "" : nil
 
         @prompt.subscribe(self)
       end
@@ -83,7 +91,7 @@ module TTY
       #
       # @api private
       def paginated?
-        @choices.size > page_size
+        choices.size > page_size
       end
 
       # @param [String] text
@@ -111,7 +119,16 @@ module TTY
       #
       # @api public
       def default_help
-        self.class::HELP % [enumerate? ? " or number (1-#{@choices.size})" : '']
+        # Note that enumeration and filter are mutually exclusive
+        tokens = if enumerate?
+                   [" or number (1-#{choices.size})", ""]
+                 elsif @choices_filter
+                   ["", ", and letter keys to filter"]
+                 else
+                   ["", ""]
+                 end
+
+        format(self.class::HELP, *tokens)
       end
 
       # Set selecting active index using number pad
@@ -132,14 +149,25 @@ module TTY
         end
       end
 
-      # Add multiple choices
+      # Add multiple choices, or display them.
       #
       # @param [Array[Object]] values
-      #   the values to add as choices
+      #   the values to add as choices; if not passed, the current
+      #   choices are displayed.
       #
       # @api public
-      def choices(values)
-        Array(values).each { |val| choice(*val) }
+      def choices(values = (not_set = true))
+        if not_set
+          if @choices_filter.to_s != ""
+            @choices.select do |the_choice|
+              the_choice.name.downcase.include?(@choices_filter.downcase)
+            end
+          else
+            @choices
+          end
+        else
+          Array(values).each { |val| choice(*val) }
+        end
       end
 
       # Call the list menu by passing question and choices
@@ -166,26 +194,26 @@ module TTY
       def keynum(event)
         return unless enumerate?
         value = event.value.to_i
-        return unless (1..@choices.count).cover?(value)
+        return unless (1..choices.count).cover?(value)
         @active = value
       end
 
       def keyenter(*)
-        @done = true
+        @done = true unless choices.empty?
       end
       alias keyreturn keyenter
       alias keyspace keyenter
 
       def keyup(*)
         if @active == 1
-          @active = @choices.length if @cycle
+          @active = choices.length if @cycle
         else
           @active -= 1
         end
       end
 
       def keydown(*)
-        if @active == @choices.length
+        if @active == choices.length
           @active = 1 if @cycle
         else
           @active += 1
@@ -193,7 +221,37 @@ module TTY
       end
       alias keytab keydown
 
+      def keypress(event)
+        return unless @choices_filter
+
+        if event.value =~ FILTER_KEYS_MATCHER
+          @choices_filter += event.value
+          @active = 1
+        end
+      end
+
+      def keydelete(*)
+        return unless @choices_filter
+
+        @choices_filter = ""
+        @active = 1
+      end
+
+      def keybackspace(*)
+        return unless @choices_filter
+
+        @choices_filter = @choices_filter[0..-2]
+        @active = 1
+      end
+
       private
+
+      def check_options_consistency(options)
+        if options.key?(:enum) && options.key?(:filter)
+          raise ConfigurationError,
+                "Enumeration can't be used with filter"
+        end
+      end
 
       # Setup default option and active selection
       #
@@ -210,11 +268,11 @@ module TTY
         @default.each do |d|
           if d.nil? || d.to_s.empty?
             raise ConfigurationError,
-                 "default index must be an integer in range (1 - #{@choices.size})"
+                 "default index must be an integer in range (1 - #{choices.size})"
           end
-          if d < 1 || d > @choices.size
+          if d < 1 || d > choices.size
             raise ConfigurationError,
-                 "default index `#{d}` out of range (1 - #{@choices.size})"
+                 "default index `#{d}` out of range (1 - #{choices.size})"
           end
         end
       end
@@ -233,7 +291,12 @@ module TTY
           question = render_question
           @prompt.print(question)
           @prompt.read_keypress
-          @prompt.print(refresh(question.lines.count))
+
+          # Split manually; if the second line is blank (when there are not
+          # matching lines), it won't be included by using String#lines.
+          question_lines = question.split($INPUT_RECORD_SEPARATOR, -1)
+
+          @prompt.print(refresh(question_lines.count))
         end
         @prompt.print(render_question)
         answer
@@ -247,7 +310,7 @@ module TTY
       #
       # @api private
       def answer
-        @choices[@active - 1].value
+        choices[@active - 1].value
       end
 
       # Clear screen lines
@@ -280,10 +343,12 @@ module TTY
       # @api private
       def render_header
         if @done
-          selected_item = "#{@choices[@active - 1].name}"
+          selected_item = "#{choices[@active - 1].name}"
           @prompt.decorate(selected_item, @active_color)
         elsif @first_render
           @prompt.decorate(help, @help_color)
+        elsif @choices_filter.to_s != ""
+          @prompt.decorate(filter_help, @help_color)
         end
       end
 
@@ -294,7 +359,8 @@ module TTY
       # @api private
       def render_menu
         output = ''
-        @paginator.paginate(@choices, @active, @per_page) do |choice, index|
+
+        @paginator.paginate(choices, @active, @per_page) do |choice, index|
           num = enumerate? ? (index + 1).to_s + @enum + ' ' : ''
           message = if index + 1 == @active
                       selected = @marker + ' ' + num + choice.name
@@ -302,10 +368,11 @@ module TTY
                     else
                       ' ' * 2 + num + choice.name
                     end
-          max_index = paginated? ? @paginator.max_index : @choices.size - 1
+          max_index = paginated? ? @paginator.max_index : choices.size - 1
           newline = (index == max_index) ? '' : "\n"
           output << (message + newline)
         end
+
         output
       end
 
@@ -318,6 +385,15 @@ module TTY
         return '' unless paginated?
         colored_footer = @prompt.decorate(@page_help, @help_color)
         "\n" << colored_footer
+      end
+
+      # Header part showing the current filter
+      #
+      # @return String
+      #
+      # @api private
+      def filter_help
+        "(Filter: #{@choices_filter.inspect})"
       end
     end # List
   end # Prompt


### PR DESCRIPTION
Give the user the ability to filter the current list entries using alphanumeric characters and a few other characters, the same way Github multiple choice widgets work.

Sample instantiation and output:

```ruby
prompt.select("Select drinks?", %w(vodka beer wine whisky bourbon), filter: true)
```

```
    Select drinks? (Pattern: "k")
    ‣ vodka
      whisky
```

This option, activated via `filter: true` is incompatible with the enumeration, in order to avoid ambiguity when typing numbers.

An alternative code design is to make `@choices` mutable, and store the original choices in a separate variable; this minimizes the changes, at the cost of increased mutability.

Closes #71.