### PR TITLE
Add Ruby dotfiles (.ruby-{version,gemset}) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /.bundle/
+/.ruby-version
+/.ruby-gemset
 /.yardoc
 /Gemfile.lock
 /_yardoc/


### PR DESCRIPTION
Add Ruby dotfiles (.ruby-{version,gemset}), to automate management (for RVM users).

@piotrmurach this is mostly a proposal, since I don't know what's your opinion on Ruby version management. I think it would be useful to have it, and possibly to add also the other Ruby version manager dotfiles, since they don't affect the project, and make working smoother for developers working on it.

ps. sorry for the auto-assignment. it's an automation I'll remove.