### PR TITLE
Support array values for answer collector keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,33 @@ end
 # {:name => "Piotr", :age => 30, :address => {:street => "Street", :city => "City", :zip => "123"}}
 ```
 
+In order to collect _mutliple values_ for a given key in a loop, chain `values` onto the `key` desired:
+
+```rb
+result = prompt.collect do
+  key(:name).ask('Name?')
+
+  key(:age).ask('Age?', convert: :int)
+
+  while prompt.yes?("continue?")
+    key(:addresses).values do
+      key(:street).ask('Street?', required: true)
+      key(:city).ask('City?')
+      key(:zip).ask('Zip?', validate: /\A\d{3}\Z/)
+    end
+  end
+end
+# =>
+# {
+#   :name => "Piotr",
+#   :age => 30,
+#   :addresses => [
+#     {:street => "Street", :city => "City", :zip => "123"},
+#     {:street => "Street", :city => "City", :zip => "234"}
+#   ]
+# }
+```
+
 ## 2. Interface
 
 ### 2.1 ask

--- a/lib/tty/prompt/answers_collector.rb
+++ b/lib/tty/prompt/answers_collector.rb
@@ -31,7 +31,16 @@ module TTY
       def key(name, &block)
         @name = name
         if block
-          answer = create_collector.(&block)
+          answer = create_collector.call(&block)
+          add_answer(answer)
+        end
+        self
+      end
+
+      def values(&block)
+        @answers[@name] = @answers.key?(@name) ? [*@answers[@name]] : []
+        if block
+          answer = create_collector.call(&block)
           add_answer(answer)
         end
         self
@@ -44,7 +53,11 @@ module TTY
 
       # @api public
       def add_answer(answer)
-        @answers[@name] = answer
+        if @answers[@name].is_a?(Array)
+          @answers[@name] << answer
+        else
+          @answers[@name] = answer
+        end
       end
 
       private

--- a/spec/unit/collect_spec.rb
+++ b/spec/unit/collect_spec.rb
@@ -4,6 +4,69 @@ RSpec.describe TTY::Prompt, '#collect' do
 
   subject(:prompt) { TTY::TestPrompt.new }
 
+  def collect(&block)
+    prompt = subject
+    count = 0
+
+    result = prompt.collect do
+      while prompt.yes?("continue?")
+        instance_eval(&block)
+        count += 1
+      end
+    end
+
+    result[:count] = count
+    result
+  end
+
+  context "when receiving multiple answers" do
+    let(:colors) { %w(red blue yellow) }
+
+    before do
+      subject.input << "y\r" + colors.join("\ry\r") + "\rn\r"
+      subject.input.rewind
+    end
+
+    it "collects as a list if values method used in chain" do
+      result = collect { key(:colors).values.ask("color:") }
+      expect(result[:count]).to eq(3)
+      expect(result[:colors]).to eq(colors)
+    end
+
+    it "collects as a list if values method used in chain with block" do
+      result = collect do
+        key(:colors).values { key(:name).ask("color:") }
+      end
+      expect(result[:count]).to eq(3)
+      expect(result[:colors]).to eq(colors.map { |c| { name: c } })
+    end
+
+    context "with multiple keys" do
+      let(:colors) { ["red\rblue", "yellow\rgreen"] }
+      let(:expected_pairs) do
+        colors.map { |s| Hash[%i(hot cold).zip(s.split("\r"))] }
+      end
+
+      it "collects into the appropriate keys" do
+        result = collect do
+          key(:pairs).values do
+            key(:hot).ask("color:")
+            key(:cold).ask("color:")
+          end
+        end
+
+        expect(result[:count]).to eq(2)
+        expect(result[:pairs]).to eq(expected_pairs)
+      end
+    end
+
+    it "overrides a non-array key on multiple answers" do
+      result = collect { key(:colors).ask("color:") }
+      expect(result[:colors]).to eq(colors.last)
+      expect(result[:count]).to eq(3)
+    end
+  end
+
   it "collects more than one answer" do
     prompt.input << "Piotr\r30\rStreet\rCity\r123\r"
     prompt.input.rewind


### PR DESCRIPTION
I'm working on a project where I want to be able to keep a loop going, getting feedback from users and storing them all in the `result` returned from an `AnswerCollector`. This PR allows collector consumers to receive multiple values from `key`-ed prompts if the key name is shared.

I feel like there is value in this being optional - where the default behavior would be to _override_ the value of a key if it appears multiple times - but couldn't figure out a clean way to implement an additional option to the `key` method; was thinking something like:

```rb
def key(name, multi: false, &block)
  @name = name
  @multi = multi
  # ...
end
```