### PR TITLE
Relax timers gem requirement to 4.*

### DIFF
--- a/tty-prompt.gemspec
+++ b/tty-prompt.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'necromancer',  '~> 0.4.0'
   spec.add_dependency 'pastel',       '~> 0.7.0'
-  spec.add_dependency 'timers',       '~> 4.1.2'
+  spec.add_dependency 'timers',       '~> 4.0'
   spec.add_dependency 'tty-cursor',   '~> 0.5.0'
   spec.add_dependency 'tty-reader',   '~> 0.2.0'
 


### PR DESCRIPTION
Requiring an overly specific version of gems results in conflicts if the
user has another gem that requires a different version. For example, if
another gem specifies `gem 'timers', '~> 4.0.0'`, that gem constraint
cannot be satisfied at the same time as `~> 4.1`.

For example, here's a conflict with Celluloid. The Celluloid gem since then has loosened their constraint to `~> 4`. https://github.com/celluloid/celluloid/blob/5ed21e862d979faa933ab724d7c3e435ce14bbf0/celluloid.gemspec#L27

```
Bundler could not find compatible versions for gem "timers":
  In Gemfile:
    berkshelf (~> 6.3) was resolved to 6.3.1, which depends on
      ridley (~> 5.0) was resolved to 5.1.1, which depends on
        celluloid (~> 0.16.0) was resolved to 0.16.0, which depends on
          timers (~> 4.0.0)

    tty-prompt (~> 0.14) was resolved to 0.14.0, which depends on
      timers (~> 4.1.2)
```