### PR TITLE
Fixes error when backspace is 1st keypress on filtered select

### DIFF
--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -50,7 +50,9 @@ module TTY
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
         @marker       = options.fetch(:marker) { symbols[:pointer] }
         @cycle        = options.fetch(:cycle) { false }
-        @filter       = options.fetch(:filter) { false } ? '' : nil
+        # String#+@ unfreezes (if necessary) a String instance
+        # We want to do this because we're going to potentially modify @filter
+        @filter       = options.fetch(:filter) { false } ? +"" : nil
         @help         = options[:help]
         @first_render = true
         @done         = false


### PR DESCRIPTION
Because frozen string literals are enabled, the empty string assigned to `@filter` on List instantiation is a frozen string. Most of the time, `List#keypress` unfreezes `@filter` because it overwrites it.
However, when backspace is the first keypress, `@filter.slice!` blows up because it's trying to modify a frozen string.

2 ways to fix this issue:
1. change `List#keybackspace` to overwrite `@filter` like the other methods that interact with `@filter`
2. instantiate `@filter` as an unfrozen string literal

I chose option 2 because it solves this specific problem and also solves any similar problems in any other methods (present or future) that interact with `@filter`.

### Describe the change
Makes `@filter` in `List` an unfrozen String literal, because it's potentially going to get modified a lot during the lifetime of the `List` instance.

### Why are we doing this?
So that filtered selects don't blow up with certain key sequences anymore.

### Benefits
Filtered selects don't blow up with certain key sequences anymore.

### Drawbacks
I see none.

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
(I can write you a test if you want, but doing so seems like it falls into the "write a regression test for every little thing that's ever broken before" anti-pattern)
[X] Code style checked?
[] Rebased with `master` branch?
(it's a a single commit, so I assume this is unnecessary)
[] Documentation updated?
(no changes needed to docs)
