### PR TITLE
made select `@filter` an array to avoid frozen string issues

### DIFF
--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -71,11 +71,11 @@ module TTY
         if @done && @echo
           @prompt.decorate(selected_names, @active_color)
         elsif @selected.size.nonzero? && @echo
-          help_suffix = @filter.to_s != "" ? " #{filter_help}" : ""
+          help_suffix = filterable? && @filter.any? ? " #{filter_help}" : ""
           selected_names + (@first_render ? " #{instructions}" : help_suffix)
         elsif @first_render
           instructions
-        elsif @filter.to_s != ""
+        elsif filterable? && @filter.any?
           filter_help
         end
       end


### PR DESCRIPTION
Also separated `@filter` from `@filterable` so we can avoid semantically overloading `@filter` to also tell us when filtering has been enabled.

### Why are we doing this?
https://github.com/piotrmurach/tty-prompt/pull/88#issuecomment-426027325

### Benefits
Won't have frozen string issues with `@filter` in `List` and `MultiList` instances.

### Drawbacks
I've invalidated some contributors' knowledge about some of the `List` and `MultiList` internals by separating `@filter` and `@filterable`, but I think doing so makes the code more explicit about it's intent and what certain conditionals are actually trying to check.

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
(didn't write new ones, but they all pass)
[X] Code style checked?
[] Rebased with `master` branch?
(single commit)
[] Documentaion updated?
(no need to; this is an internal change)
