### PR TITLE
Slider format as Proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1211,6 +1211,15 @@ prompt.slider('Volume', max: 100, step: 5, default: 75, format: "|:slider| %d%")
 # (Use arrow keys, press Enter to select)
 ```
 
+Format could be defined as String or as Proc:
+
+```ruby
+prompt.slider('Volume', max: 100, step: 5, default: 75, format: lambda {|v| "|:slider| #{v/10}%" })
+# =>
+# Volume |───────────────O─────| 7.5%
+# (Use arrow keys, press Enter to select)
+```
+
 Slider can be configured through DSL as well:
 
 ```ruby

--- a/lib/tty/prompt/slider.rb
+++ b/lib/tty/prompt/slider.rb
@@ -25,7 +25,7 @@ module TTY
       # @option options [Integer] :min The minimum value
       # @option options [Integer] :max The maximum value
       # @option options [Integer] :step The step value
-      # @option options [String] :format The display format
+      # @option options [String, Proc] :format The display format
       #
       # @api public
       def initialize(prompt, options = {})
@@ -185,7 +185,12 @@ module TTY
                  @prompt.decorate(symbols[:handle], @active_color) +
                  (symbols[:line] * (range.size - @active - 1))
         value = " #{range[@active]}"
-        @format.gsub(':slider', slider) % [value]
+
+        if @format.is_a?(Proc)
+          @format.call(value).gsub(':slider', slider)
+        else
+          @format.gsub(':slider', slider) % [value]
+        end
       end
     end # Slider
   end # Prompt

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -97,4 +97,21 @@ RSpec.describe TTY::Prompt, '#slider' do
       "What size? \e[32m10\e[0m\n\e[?25h"
     ].join)
   end
+
+  it 'format slider with Proc' do
+    prompt.input << "\r"
+    prompt.input.rewind
+    options = { max: 10, format: lambda { |value| ":slider #{value.to_f/10}" } }
+    value = prompt.slider('What size?', options)
+    expect(value).to eq(5)
+    expect(prompt.output.string).to eq([
+      "\e[?25lWhat size? ",
+      symbols[:line] * 5,
+      "\e[32m#{symbols[:handle]}\e[0m",
+      "#{symbols[:line] * 5} 0.5",
+      "\n\e[90m(Use arrow keys, press Enter to select)\e[0m",
+      "\e[2K\e[1G\e[1A\e[2K\e[1G",
+      "What size? \e[32m5\e[0m\n\e[?25h"
+    ].join)
+  end
 end


### PR DESCRIPTION
### Describe the change
Defined format for slider via Proc.

### Why are we doing this?
I would like to have `:step` options as Float but its not possible. However with this I can multiple numbers by 10 and format the output with float.

```ruby
# Not possible
prompt.slider('Volume', max: 10, step: 0.5, format: "|:slider| %d")

prompt.slider('Volume', max: 100, step: 5, format: lambda {|value| "|:slider| #{value/10}" })
```

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentaion updated?
