### PR TITLE
[Resolves #91] Invalid characters on suffix

### DIFF
--- a/lib/tty/prompt/confirm_question.rb
+++ b/lib/tty/prompt/confirm_question.rb
@@ -122,7 +122,9 @@ module TTY
       # @api private
       def conversion
         proc { |input|
-          regex = Regexp.new(Regexp.escape("^#{positive}|#{positive[0]}$/i"))
+          r1 = Regexp.escape(positive)
+          r2 = Regexp.escape(positive[0])
+          regex = Regexp.new("^#{r1}|#{r2}$", true)
           !input.match(regex).nil?
         }
       end

--- a/lib/tty/prompt/confirm_question.rb
+++ b/lib/tty/prompt/confirm_question.rb
@@ -121,7 +121,10 @@ module TTY
       #
       # @api private
       def conversion
-        proc { |input| !input.match(/^#{positive}|#{positive[0]}$/i).nil? }
+        proc { |input|
+          regex = Regexp.new(Regexp.escape("^#{positive}|#{positive[0]}$/i"))
+          !input.match(regex).nil?
+        }
       end
     end # ConfirmQuestion
   end # Prompt

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -98,16 +98,16 @@ RSpec.describe TTY::Prompt, 'confirmation' do
     it "accepts regex conflicting characters as suffix" do
       prompt.input << "]\n"
       prompt.input.rewind
-      result = prompt.yes?("Are you a human? Use [ for yes and ] for no") do |q|
-        q.suffix '[/]'
+      result = prompt.yes?("Are you a human? [ as yes and ] as no") do |q|
+        q.suffix "[/]"
       end
       expect(result).to eq(false)
       expect(prompt.output.string).to eq([
-        "Are you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ",
-        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ]",
-        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ]\n",
+        "Are you a human? [ as yes and ] as no \e[90m([/])\e[0m ",
+        "\e[2K\e[1GAre you a human? [ as yes and ] as no \e[90m([/])\e[0m ]",
+        "\e[2K\e[1GAre you a human? [ as yes and ] as no \e[90m([/])\e[0m ]\n",
         "\e[1A\e[2K\e[1G",
-        "Are you a human? Use [ for yes and ] for no \e[32m]\e[0m\n"
+        "Are you a human? [ as yes and ] as no \e[32m]\e[0m\n"
       ].join)
     end
 

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -135,6 +135,25 @@ RSpec.describe TTY::Prompt, 'confirmation' do
         "Are you a human? \e[32mDisagree\e[0m\n"
       ].join)
     end
+
+    it "accepts any character as suffix" do
+      prompt.input << "[\n"
+      prompt.input.rewind
+      result = prompt.yes?("Are you human? Use [ for yes and ] for no") do |q|
+        q.suffix '[/]'
+      end
+      expect(result).to eq(false)
+      expect(prompt.output.string).to eq([
+        "Are you a human? \e[90m(Yup/nope)\e[0m ",
+        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m N",
+        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m No",
+        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m Nop",
+        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m Nope",
+        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m Nope\n",
+        "\e[1A\e[2K\e[1G",
+        "Are you a human? \e[32mnope\e[0m\n"
+      ].join)
+    end
   end
 
   context '#no?' do

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -95,6 +95,22 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
+    it "accepts regex conflicting characters as suffix" do
+      prompt.input << "]\n"
+      prompt.input.rewind
+      result = prompt.yes?("Are you a human? Use [ for yes and ] for no") do |q|
+        q.suffix '[/]'
+      end
+      expect(result).to eq(false)
+      expect(prompt.output.string).to eq([
+        "Are you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ",
+        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ]",
+        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ]\n",
+        "\e[1A\e[2K\e[1G",
+        "Are you a human? Use [ for yes and ] for no \e[32m]\e[0m\n"
+      ].join)
+    end
+
     it "customizes question through options" do
       prompt.input << "\r"
       prompt.input.rewind
@@ -133,21 +149,6 @@ RSpec.describe TTY::Prompt, 'confirmation' do
         "\e[2K\e[1GAre you a human? \e[90m(Agree/Disagree)\e[0m disagree\n",
         "\e[1A\e[2K\e[1G",
         "Are you a human? \e[32mDisagree\e[0m\n"
-      ].join)
-    end
-
-    it "accepts regex conflicting characters as suffix" do
-      prompt.input << "]\n"
-      prompt.input.rewind
-      result = prompt.yes?("Are you a human? Use [ for yes and ] for no") do |q|
-        q.suffix '[/]'
-      end
-      expect(result).to eq(false)
-      expect(prompt.output.string).to eq([
-        "Are you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ",
-        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m [",
-        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m [\n",
-        "Are you a human? Use [ for yes and ] for no \e[32m[\e[0m\n"
       ].join)
     end
   end

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -136,22 +136,18 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it "accepts any character as suffix" do
-      prompt.input << "[\n"
+    it "accepts regex conflicting characters as suffix" do
+      prompt.input << "]\n"
       prompt.input.rewind
-      result = prompt.yes?("Are you human? Use [ for yes and ] for no") do |q|
+      result = prompt.yes?("Are you a human? Use [ for yes and ] for no") do |q|
         q.suffix '[/]'
       end
       expect(result).to eq(false)
       expect(prompt.output.string).to eq([
-        "Are you a human? \e[90m(Yup/nope)\e[0m ",
-        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m N",
-        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m No",
-        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m Nop",
-        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m Nope",
-        "\e[2K\e[1GAre you a human? \e[90m(Yup/nope)\e[0m Nope\n",
-        "\e[1A\e[2K\e[1G",
-        "Are you a human? \e[32mnope\e[0m\n"
+        "Are you a human? Use [ for yes and ] for no \e[90m([/])\e[0m ",
+        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m [",
+        "\e[2K\e[1GAre you a human? Use [ for yes and ] for no \e[90m([/])\e[0m [\n",
+        "Are you a human? Use [ for yes and ] for no \e[32m[\e[0m\n"
       ].join)
     end
   end


### PR DESCRIPTION
### Describe the change
On the conversion of the user input, instead of blindly generating the regex for matching based on the configured `positive` value we ensure that the value for positive is escaped if needed, by invoking Regexp.escape.

### Why are we doing this?
Building the regex blindly based on the user suffix param, in case he/she uses characters that conflict with the regex definition itself, it makes the prompt crash.

### Benefits
When adding this, the suffix option for the prompt will support characters that otherwise would crash the regex definition.

### Drawbacks
None that I can think of

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
Tried to follow the patterns I've identified in the existing codebase but i might have missed something.
[x] Rebased with `master` branch?
[] Documentaion updated?
There is no need for updated documentation in my opinion
