### PR TITLE
Feature/expander default hint

### DIFF
--- a/lib/tty/prompt/expander.rb
+++ b/lib/tty/prompt/expander.rb
@@ -210,11 +210,8 @@ module TTY
       #
       # @api private
       def render_question
+        load_auto_hint if @auto_hint
         header = render_header
-        if !@hint && @auto_hint
-          default_choice = select_choice(@choices[@default - 1].key)
-          @hint = default_choice.name
-        end
         header << render_hint if @hint
         header << "\n" if @done
 
@@ -223,6 +220,13 @@ module TTY
           header << render_footer
         end
         header
+      end
+
+      def load_auto_hint
+        if @hint.nil?
+          default_choice = select_choice(@choices[@default - 1].key)
+          @hint = default_choice.name
+        end
       end
 
       def render_footer

--- a/lib/tty/prompt/expander.rb
+++ b/lib/tty/prompt/expander.rb
@@ -30,6 +30,7 @@ module TTY
         @done         = false
         @status       = :collapsed
         @hint         = nil
+        @auto_hint = options.fetch(:auto_hint) { false }
         @default_key  = false
       end
 
@@ -210,6 +211,10 @@ module TTY
       # @api private
       def render_question
         header = render_header
+        if !@hint && @auto_hint
+          default_choice = select_choice(@choices[@default - 1].key)
+          @hint = default_choice.name
+        end
         header << render_hint if @hint
         header << "\n" if @done
 


### PR DESCRIPTION
### Describe the change
Implements a new option for the `Expander` class to allow for automatically hinting the default option.

### Why are we doing this?
It has the benefit of always keeping the number of lines output by the expander to be the same. This is helpful when other rendered text can  be misplaced bay the addition of the hint.

### Benefits
Slightly more flexible

### Drawbacks
Could get messy having too many options

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[X] Rebased with `master` branch?
[] Documentaion updated?
