### PR TITLE
Update choice.rb

### DIFF
--- a/lib/tty/prompt/choice.rb
+++ b/lib/tty/prompt/choice.rb
@@ -30,8 +30,6 @@ module TTY
         case val
         when Choice
           val
-        when String, Symbol
-          new(val, val)
         when Array
           name, value, options = *val
           if name.is_a?(Hash)
@@ -42,7 +40,7 @@ module TTY
         when Hash
           convert_hash(val)
         else
-          raise ArgumentError, "#{val} cannot be coerced into Choice"
+          new(val, val)
         end
       end
 


### PR DESCRIPTION
When converting an object to a Choice, if no explicit conversion can be used, fall back to using the object as both the name and value.

Fixes https://github.com/piotrmurach/tty-prompt/issues/97