### PR TITLE
Cache intermediate filter-results

### DIFF
--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -48,6 +48,7 @@ module TTY
         @filterable   = options.fetch(:filter) { false }
         @symbols      = @prompt.symbols.merge(options.fetch(:symbols, {}))
         @filter       = []
+        @filter_cache = {}
         @help         = options[:help]
         @first_render = true
         @done         = false
@@ -171,6 +172,7 @@ module TTY
       #
       # @api public
       def choice(*value, &block)
+        @filter_cache = {}
         if block
           @choices << (value << block)
         else
@@ -190,12 +192,14 @@ module TTY
           if !filterable? || @filter.empty?
             @choices
           else
-            @choices.select do |choice|
+            filter_value = @filter.join.downcase
+            @filter_cache[filter_value] ||= @choices.select do |choice|
               !choice.disabled? &&
-                choice.name.downcase.include?(@filter.join.downcase)
+                choice.name.downcase.include?(filter_value)
             end
           end
         else
+          @filter_cache = {}
           values.each { |val| @choices << val }
         end
       end


### PR DESCRIPTION
### Describe the change

Optimise filtering very large sets of choices by not computing the filter-value inside the loop, and by caching each result-set (and resetting it completely when adding items)

### Why are we doing this?

I'm using very large lists of choices (9000 items), and with an active filter, it'd take more than a second to redraw the menu when using arrow-keys or adding more filtering.

### Benefits

Large lists will perform better.

### Drawbacks

Memory usage will increase due to caching the result sets.

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[] Code style checked?
[] Rebased with `master` branch?
[] Documentaion updated?
