### PR TITLE
Add a :quiet option to disable final output of certain classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Or install it yourself as:
   * [3.4 :help_color](#34-help_color)
   * [3.5 :interrupt](#35-interrupt)
   * [3.6 :prefix](#36-prefix)
-  * [3.7 :track_history](#37-track_history)
+  * [3.7 :quiet](#37-quiet)
+  * [3.8 :track_history](#38-track_history)
 
 ## 1. Usage
 
@@ -1010,7 +1011,7 @@ In order to ask for standard selection from indexed list you can use `enum_selec
 
 ```ruby
 choices = %w(emacs nano vim)
-prompt.enum_select("Select an editor?")
+prompt.enum_select("Select an editor?", choices)
 # =>
 #
 # Select an editor?
@@ -1023,7 +1024,6 @@ prompt.enum_select("Select an editor?")
 Similar to `select` and `multi_select`, you can provide question options through DSL using `choice` method and/or `choices` like so:
 
 ```ruby
-choices = %w(nano vim emacs)
 prompt.enum_select("Select an editor?") do |menu|
   menu.choice :nano,  '/bin/nano'
   menu.choice :vim,   '/usr/bin/vim'
@@ -1043,7 +1043,6 @@ end
 You can change the indexed numbers by passing `enum` option and the default option by using `default` like so
 
 ```ruby
-choices = %w(nano vim emacs)
 prompt.enum_select("Select an editor?") do |menu|
   menu.default 2
   menu.enum '.'
@@ -1456,7 +1455,7 @@ Please [see pastel](https://github.com/piotrmurach/pastel#3-supported-colors) fo
 If you wish to disable coloring for a prompt simply pass `:enable_color` option
 
 ```ruby
-prompt = TTY::Prompt.new(enable_color: true)
+prompt = TTY::Prompt.new(enable_color: false)
 ```
 
 ### 3.4 `:help_color`
@@ -1496,7 +1495,19 @@ You can prefix each question asked using the `:prefix` option. This option can b
 prompt = TTY::Prompt.new(prefix: '[?] ')
 ```
 
-### 3.7 `:track_history`
+### 3.7 `:quiet`
+
+Prompts such as `select`, `multi_select`, `expand`, `slider` support `:quiet` which is used to disable re-echoing of the question and answer after selection is done. This option can be applied either globally for all prompts or individually.
+
+```ruby
+# global
+prompt = TTY::Prompt.new(quiet: true)
+
+# single prompt
+prompt.select("What is your favorite color?", %w( blue yellow orange ))
+```
+
+### 3.8 `:track_history`
 
 The prompts that accept line input such as `multiline` or `ask` provide history buffer that tracks all the lines entered during `TTY::Prompt.new` interactions. The history buffer provides previous or next lines when user presses up/down arrows respectively. However, if you wish to disable this behaviour use `:track_history` option like so:
 

--- a/lib/tty-prompt.rb
+++ b/lib/tty-prompt.rb
@@ -1,2 +1,3 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 require_relative 'tty/prompt'
 require_relative 'tty/test_prompt'

--- a/lib/tty/prompt.rb
+++ b/lib/tty/prompt.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require 'forwardable'
@@ -71,6 +72,11 @@ module TTY
     # @api private
     attr_reader :active_color, :help_color, :error_color, :enabled_color
 
+    # Quiet mode
+    #
+    # @api private
+    attr_reader :quiet
+
     # The collection of display symbols
     #
     # @example
@@ -123,6 +129,8 @@ module TTY
     #   handling of Ctrl+C key out of :signal, :exit, :noop
     # @option options [Boolean] :track_history
     #   disable line history tracking, true by default
+    # @option options [Boolean] :quiet
+    #   enable quiet mode, don't re-echo the question
     # @option options [Hash] :symbols
     #   the symbols displayed in prompts such as :marker, :cross
     #
@@ -134,11 +142,12 @@ module TTY
       @env    = options.fetch(:env) { ENV }
       @prefix = options.fetch(:prefix) { '' }
       @enabled_color = options[:enable_color]
-      @active_color  = options.fetch(:active_color) { :green }
-      @help_color    = options.fetch(:help_color)   { :bright_black }
-      @error_color   = options.fetch(:error_color)  { :red }
-      @interrupt     = options.fetch(:interrupt)    { :error }
+      @active_color  = options.fetch(:active_color)  { :green }
+      @help_color    = options.fetch(:help_color)    { :bright_black }
+      @error_color   = options.fetch(:error_color)   { :red }
+      @interrupt     = options.fetch(:interrupt)     { :error }
       @track_history = options.fetch(:track_history) { true }
+      @quiet         = options.fetch(:quiet)         { false }
       @symbols       = Symbols.symbols.merge(options.fetch(:symbols, {}))
 
       @cursor = TTY::Cursor
@@ -566,6 +575,7 @@ module TTY
         input: input,
         output: output,
         prefix: prefix,
+        quiet: quiet,
         active_color: active_color,
         error_color: error_color,
         enabled_color: enabled_color,

--- a/lib/tty/prompt/answers_collector.rb
+++ b/lib/tty/prompt/answers_collector.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/block_paginator.rb
+++ b/lib/tty/prompt/block_paginator.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'paginator'

--- a/lib/tty/prompt/choice.rb
+++ b/lib/tty/prompt/choice.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require 'forwardable'

--- a/lib/tty/prompt/confirm_question.rb
+++ b/lib/tty/prompt/confirm_question.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'question'

--- a/lib/tty/prompt/converter_dsl.rb
+++ b/lib/tty/prompt/converter_dsl.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'converter_registry'

--- a/lib/tty/prompt/converter_registry.rb
+++ b/lib/tty/prompt/converter_registry.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/converters.rb
+++ b/lib/tty/prompt/converters.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require 'pathname'

--- a/lib/tty/prompt/distance.rb
+++ b/lib/tty/prompt/distance.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/enum_list.rb
+++ b/lib/tty/prompt/enum_list.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require 'English'
@@ -27,6 +28,7 @@ module TTY
         @help_color   = options.fetch(:help_color)   { @prompt.help_color }
         @error_color  = options.fetch(:error_color)  { @prompt.error_color }
         @cycle        = options.fetch(:cycle) { false }
+        @quiet        = options.fetch(:quiet) { @prompt.quiet }
         @symbols      = @prompt.symbols.merge(options.fetch(:symbols, {}))
         @input        = nil
         @done         = false
@@ -99,6 +101,13 @@ module TTY
       # @api public
       def enum(value)
         @enum = value
+      end
+
+      # Set quiet mode
+      #
+      # @api public
+      def quiet(value)
+        @quiet = value
       end
 
       # Add a single choice
@@ -253,7 +262,7 @@ module TTY
           question_lines = question.split($INPUT_RECORD_SEPARATOR, -1)
           @prompt.print(refresh(question_lines_count(question_lines)))
         end
-        @prompt.print(render_question)
+        @prompt.print(render_question) unless @quiet
         answer
       end
 

--- a/lib/tty/prompt/evaluator.rb
+++ b/lib/tty/prompt/evaluator.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'result'

--- a/lib/tty/prompt/expander.rb
+++ b/lib/tty/prompt/expander.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'choices'
@@ -25,6 +26,7 @@ module TTY
         @auto_hint    = options.fetch(:auto_hint) { false }
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
+        @quiet        = options.fetch(:quiet) { @prompt.quiet }
         @choices      = Choices.new
         @selected     = nil
         @done         = false
@@ -103,6 +105,13 @@ module TTY
         @default = value
       end
 
+      # Set quiet mode.
+      #
+      # @api public
+      def quiet(value)
+        @quiet = value
+      end
+
       # Add a single choice
       #
       # @api public
@@ -166,7 +175,7 @@ module TTY
           read_input
           @prompt.print(refresh(question.lines.count))
         end
-        @prompt.print(render_question)
+        @prompt.print(render_question) unless @quiet
         answer
       end
 

--- a/lib/tty/prompt/keypress.rb
+++ b/lib/tty/prompt/keypress.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'question'

--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require 'English'
@@ -44,6 +45,7 @@ module TTY
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
         @cycle        = options.fetch(:cycle) { false }
         @filterable   = options.fetch(:filter) { false }
+        @quiet        = options.fetch(:quiet) { @prompt.quiet }
         @symbols      = @prompt.symbols.merge(options.fetch(:symbols, {}))
         @filter       = []
         @filter_cache = {}
@@ -171,6 +173,13 @@ module TTY
       # @api public
       def enum(value)
         @enum = value
+      end
+
+      # Set whether selected answers are echoed
+      #
+      # @api public
+      def quiet(value)
+        @quiet = value
       end
 
       # Add a single choice
@@ -411,7 +420,7 @@ module TTY
 
           @prompt.print(refresh(question_lines_count(question_lines)))
         end
-        @prompt.print(render_question)
+        @prompt.print(render_question) unless @quiet
         answer
       ensure
         @prompt.print(@prompt.show)

--- a/lib/tty/prompt/mask_question.rb
+++ b/lib/tty/prompt/mask_question.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'question'
@@ -14,6 +15,7 @@ module TTY
       def initialize(prompt, **options)
         super
         @mask        = options.fetch(:mask) { @prompt.symbols[:dot] }
+        @quiet       = options.fetch(:quiet) { @prompt.quiet }
         @done_masked = false
         @failure     = false
       end
@@ -28,6 +30,13 @@ module TTY
       def mask(char = (not_set = true))
         return @mask if not_set
         @mask = char
+      end
+
+      # Set quiet mode.
+      #
+      # @api public
+      def quiet(value)
+        @quiet = value
       end
 
       def keyreturn(event)
@@ -85,6 +94,7 @@ module TTY
           @prompt.print(render_question)
         end
         @prompt.puts
+        @prompt.print(@prompt.clear_lines(total_lines)) if @quiet
         @input
       end
     end # MaskQuestion

--- a/lib/tty/prompt/mask_question.rb
+++ b/lib/tty/prompt/mask_question.rb
@@ -15,7 +15,6 @@ module TTY
       def initialize(prompt, **options)
         super
         @mask        = options.fetch(:mask) { @prompt.symbols[:dot] }
-        @quiet       = options.fetch(:quiet) { @prompt.quiet }
         @done_masked = false
         @failure     = false
       end
@@ -30,13 +29,6 @@ module TTY
       def mask(char = (not_set = true))
         return @mask if not_set
         @mask = char
-      end
-
-      # Set quiet mode.
-      #
-      # @api public
-      def quiet(value)
-        @quiet = value
       end
 
       def keyreturn(event)

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'list'
@@ -20,9 +21,9 @@ module TTY
       def initialize(prompt, **options)
         super
         @selected = []
-        @help = options[:help]
-        @echo = options.fetch(:echo, true)
-        @max  = options[:max]
+        @help     = options[:help]
+        @echo     = options.fetch(:echo, true)
+        @max      = options[:max]
       end
 
       # Set a maximum number of choices

--- a/lib/tty/prompt/multiline.rb
+++ b/lib/tty/prompt/multiline.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'question'

--- a/lib/tty/prompt/paginator.rb
+++ b/lib/tty/prompt/paginator.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/question.rb
+++ b/lib/tty/prompt/question.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'converters'
@@ -35,23 +36,24 @@ module TTY
       #
       # @api public
       def initialize(prompt, **options)
-        @prompt     = prompt
-        @prefix     = options.fetch(:prefix) { @prompt.prefix }
-        @default    = options.fetch(:default) { UndefinedSetting }
-        @required   = options.fetch(:required) { false }
-        @echo       = options.fetch(:echo) { true }
-        @in         = options.fetch(:in) { UndefinedSetting }
-        @modifier   = options.fetch(:modifier) { [] }
-        @validation = options.fetch(:validation) { UndefinedSetting }
-        @convert    = options.fetch(:convert) { UndefinedSetting }
+        @prompt       = prompt
+        @prefix       = options.fetch(:prefix) { @prompt.prefix }
+        @default      = options.fetch(:default) { UndefinedSetting }
+        @required     = options.fetch(:required) { false }
+        @echo         = options.fetch(:echo) { true }
+        @in           = options.fetch(:in) { UndefinedSetting }
+        @modifier     = options.fetch(:modifier) { [] }
+        @validation   = options.fetch(:validation) { UndefinedSetting }
+        @convert      = options.fetch(:convert) { UndefinedSetting }
         @active_color = options.fetch(:active_color) { @prompt.active_color }
-        @help_color = options.fetch(:help_color) { @prompt.help_color }
-        @error_color = options.fetch(:error_color) { :red }
-        @value      = options.fetch(:value) { UndefinedSetting }
-        @messages   = Utils.deep_copy(options.fetch(:messages) { { } })
-        @done       = false
+        @help_color   = options.fetch(:help_color) { @prompt.help_color }
+        @error_color  = options.fetch(:error_color) { :red }
+        @value        = options.fetch(:value) { UndefinedSetting }
+        @quiet        = options.fetch(:quiet) { @prompt.quiet }
+        @messages     = Utils.deep_copy(options.fetch(:messages) { { } })
+        @done         = false
         @first_render = true
-        @input      = nil
+        @input        = nil
 
         @evaluator = Evaluator.new(self)
 
@@ -122,7 +124,7 @@ module TTY
           total_lines = @prompt.count_screen_lines(input_line)
           @prompt.print(refresh(question.lines.count, total_lines))
         end
-        @prompt.print(render_question)
+        @prompt.print(render_question) unless @quiet
         convert_result(result.value)
       end
 
@@ -249,6 +251,13 @@ module TTY
       # @api public
       def default?
         @default != UndefinedSetting
+      end
+
+      # Set quiet mode.
+      #
+      # @api public
+      def quiet(value)
+        @quiet = value
       end
 
       # Ensure that passed argument is present or not

--- a/lib/tty/prompt/question/checks.rb
+++ b/lib/tty/prompt/question/checks.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/question/modifier.rb
+++ b/lib/tty/prompt/question/modifier.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/question/validation.rb
+++ b/lib/tty/prompt/question/validation.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/result.rb
+++ b/lib/tty/prompt/result.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/slider.rb
+++ b/lib/tty/prompt/slider.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY
@@ -33,6 +34,7 @@ module TTY
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
         @format       = options.fetch(:format) { FORMAT }
+        @quiet        = options.fetch(:quiet) { @prompt.quiet }
         @symbols      = @prompt.symbols.merge(options.fetch(:symbols, {}))
         @first_render = true
         @done         = false
@@ -91,9 +93,18 @@ module TTY
         @step = value
       end
 
+      # @api public
       def format(value)
         @format = value
       end
+
+      # Set quiet mode.
+      #
+      # @api public
+      def quiet(value)
+        @quiet = value
+      end
+
 
       # Call the slider by passing question
       #
@@ -139,7 +150,7 @@ module TTY
           @prompt.read_keypress
           refresh(question.lines.count)
         end
-        @prompt.print(render_question)
+        @prompt.print(render_question) unless @quiet
         answer
       ensure
         @prompt.print(@prompt.show)

--- a/lib/tty/prompt/slider.rb
+++ b/lib/tty/prompt/slider.rb
@@ -105,7 +105,6 @@ module TTY
         @quiet = value
       end
 
-
       # Call the slider by passing question
       #
       # @param [String] question

--- a/lib/tty/prompt/statement.rb
+++ b/lib/tty/prompt/statement.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/suggestion.rb
+++ b/lib/tty/prompt/suggestion.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'distance'

--- a/lib/tty/prompt/symbols.rb
+++ b/lib/tty/prompt/symbols.rb
@@ -1,3 +1,4 @@
+
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/timer.rb
+++ b/lib/tty/prompt/timer.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/utils.rb
+++ b/lib/tty/prompt/utils.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/prompt/version.rb
+++ b/lib/tty/prompt/version.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 module TTY

--- a/lib/tty/test_prompt.rb
+++ b/lib/tty/test_prompt.rb
@@ -1,3 +1,4 @@
+# vim: set nosta noet expandtab: ts=2 sw=2:
 # frozen_string_literal: true
 
 require_relative 'prompt'

--- a/spec/unit/ask_spec.rb
+++ b/spec/unit/ask_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe TTY::Prompt, '#ask' do
     ].join)
   end
 
+  it 'obeys quiet mode' do
+    prompt.ask('What is your name?', quiet: true)
+    expect(prompt.output.string).to eq([
+      "What is your name? ",
+      "\e[1A\e[2K\e[1G"
+    ].join)
+  end
+
   it 'asks an empty question ' do
     prompt = TTY::TestPrompt.new
     prompt.input << "\r"

--- a/spec/unit/ask_spec.rb
+++ b/spec/unit/ask_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe TTY::Prompt, '#ask' do
     ].join)
   end
 
+  it 'sets quiet mode through DSL' do
+    prompt.ask('What is your name?') do |q|
+		q.quiet true
+	end
+    expect(prompt.output.string).to eq([
+      "What is your name? ",
+      "\e[1A\e[2K\e[1G"
+    ].join)
+  end
+
   it 'asks an empty question ' do
     prompt = TTY::TestPrompt.new
     prompt.input << "\r"

--- a/spec/unit/enum_select_spec.rb
+++ b/spec/unit/enum_select_spec.rb
@@ -84,6 +84,30 @@ RSpec.describe TTY::Prompt do
     expect(prompt.output.string).to eq(expected_output)
   end
 
+  it "sets quiet mode through DSL" do
+    choices = %w(/bin/nano /usr/bin/vim.basic /usr/bin/vim.tiny)
+    prompt = TTY::TestPrompt.new
+    prompt.input << "1\n"
+    prompt.input.rewind
+    answer = prompt.enum_select("Select an editor?") do |menu|
+      menu.quiet true
+      menu.default 2
+      menu.enum '.'
+
+      menu.choice "/bin/nano"
+      menu.choice "/usr/bin/vim.basic"
+      menu.choice "/usr/bin/vim.tiny"
+    end
+    expect(answer).to eq('/bin/nano')
+
+    expected_output = [
+      output_helper("Select an editor?", choices, "/usr/bin/vim.basic", default: 2, enum: '.'),
+      output_helper("Select an editor?", choices, "/bin/nano", default: 2, enum: '.', input: 1),
+    ].join
+
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
   it "selects option by index from the list" do
     choices = %w(/bin/nano /usr/bin/vim.basic /usr/bin/vim.tiny)
     prompt = TTY::TestPrompt.new

--- a/spec/unit/enum_select_spec.rb
+++ b/spec/unit/enum_select_spec.rb
@@ -68,6 +68,22 @@ RSpec.describe TTY::Prompt do
     expect(prompt.output.string).to eq(expected_output)
   end
 
+  it "obeys quiet mode" do
+    choices = %w(/bin/nano /usr/bin/vim.basic /usr/bin/vim.tiny)
+    prompt = TTY::TestPrompt.new(quiet: true)
+    prompt.input << "\n"
+    prompt.input.rewind
+
+    answer = prompt.enum_select("Select an editor?", choices)
+    expect(answer).to eq('/bin/nano')
+
+    expected_output = [
+      output_helper("Select an editor?", choices, "/bin/nano")
+    ].join
+
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
   it "selects option by index from the list" do
     choices = %w(/bin/nano /usr/bin/vim.basic /usr/bin/vim.tiny)
     prompt = TTY::TestPrompt.new

--- a/spec/unit/expand_spec.rb
+++ b/spec/unit/expand_spec.rb
@@ -59,6 +59,28 @@ RSpec.describe TTY::Prompt, '#expand' do
     expect(prompt.output.string).to eq(expected_output)
   end
 
+  it "sets quiet mode through DSL" do
+    prompt.input << "\n"
+    prompt.input.rewind
+
+    result = prompt.expand('Overwrite Gemfile?') do |q|
+      q.choice key: 'y', name: 'Overwrite',      value: :yes
+      q.choice key: 'n', name: 'Skip',          value: :no
+      q.choice key: 'a', name: 'Overwrite all', value: :all
+      q.choice key: 'd', name: 'Show diff',     value: :diff
+      q.choice key: 'q', name: 'Quit',          value: :quit
+      q.quiet true
+    end
+    expect(result).to eq(:yes)
+
+    expected_output = [
+      "Overwrite Gemfile? (enter \"h\" for help) [\e[32my\e[0m,n,a,d,q,h] ",
+      "\e[2K\e[1G"
+    ].join
+
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
   it "changes default option" do
     prompt.input << "\n"
     prompt.input.rewind

--- a/spec/unit/expand_spec.rb
+++ b/spec/unit/expand_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe TTY::Prompt, '#expand' do
     expect(prompt.output.string).to eq(expected_output)
   end
 
+  it "obeys quiet mode" do
+    prompt.input << "\n"
+    prompt.input.rewind
+
+    result = prompt.expand('Overwrite Gemfile?', choices, quiet: true)
+    expect(result).to eq(:yes)
+
+    expected_output = [
+      "Overwrite Gemfile? (enter \"h\" for help) [\e[32my\e[0m,n,a,d,q,h] ",
+      "\e[2K\e[1G"
+    ].join
+
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
   it "changes default option" do
     prompt.input << "\n"
     prompt.input.rewind

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -68,6 +68,27 @@ RSpec.describe TTY::Prompt do
     expect(prompt.output.string).to eq(expected_output)
   end
 
+  it "obeys quiet mode" do
+    prompt = TTY::TestPrompt.new(quiet: true)
+    choices = %i(vodka beer wine whisky bourbon)
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    expect(prompt.multi_select("Select drinks?", choices)). to eq([])
+
+    expected_output = [
+      "\e[?25lSelect drinks? \e[90m(Use #{up_down} arrow keys, press Space to select and Enter to finish)\e[0m\n",
+      "#{symbols[:marker]} #{symbols[:radio_off]} vodka\n",
+      "  #{symbols[:radio_off]} beer\n",
+      "  #{symbols[:radio_off]} wine\n",
+      "  #{symbols[:radio_off]} whisky\n",
+      "  #{symbols[:radio_off]} bourbon",
+      "\e[2K\e[1G\e[1A" * 5, "\e[2K\e[1G",
+	  "\e[?25h"
+    ].join
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
   it "selects item when space pressed" do
     prompt = TTY::TestPrompt.new
     choices = %w(vodka beer wine whisky bourbon)

--- a/spec/unit/multiline_spec.rb
+++ b/spec/unit/multiline_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe TTY::Prompt::Question, '#multiline' do
     ].join)
   end
 
+  it "obeys quiet mode" do
+    prompt = TTY::TestPrompt.new(quiet: true)
+    prompt.input << "\C-d"
+    prompt.input.rewind
+
+    answer = prompt.multiline("Description?", default: 'A super sweet prompt')
+
+    expect(answer).to eq([])
+    expect(prompt.output.string).to eq([
+      "Description? \e[90m(Press CTRL-D or CTRL-Z to finish)\e[0m\n",
+      "\e[2K\e[1G\e[1A\e[2K\e[1G"
+    ].join)
+  end
+
   it "changes help text" do
     prompt = TTY::TestPrompt.new
     prompt.input << "\C-d"

--- a/spec/unit/question/quiet_spec.rb
+++ b/spec/unit/question/quiet_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe TTY::Prompt::Question, '#default' do
 
   subject(:prompt) { TTY::TestPrompt.new(quiet: true) }
 
-  it 'obeys quiet mode' do
+  it "obeys quiet mode" do
     name = 'Anonymous'
     prompt.input << "\n"
     prompt.input.rewind

--- a/spec/unit/question/quiet_spec.rb
+++ b/spec/unit/question/quiet_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Prompt::Question, '#default' do
+
+  subject(:prompt) { TTY::TestPrompt.new(quiet: true) }
+
+  it 'obeys quiet mode' do
+    name = 'Anonymous'
+    prompt.input << "\n"
+    prompt.input.rewind
+    answer = prompt.ask('What is your name?', default: name)
+    expect(answer).to eq(name)
+    expect(prompt.output.string).to eq([
+      "What is your name? \e[90m(Anonymous)\e[0m ",
+      "\e[2K\e[1GWhat is your name? \e[90m(Anonymous)\e[0m \n",
+      "\e[1A\e[2K\e[1G",
+    ].join)
+  end
+end

--- a/spec/unit/select_spec.rb
+++ b/spec/unit/select_spec.rb
@@ -104,6 +104,22 @@ RSpec.describe TTY::Prompt, '#select' do
     ].join)
   end
 
+  it "obeys quiet mode" do
+    choices = {large: 1, medium: 2, small: 3}
+    prompt.input << " "
+    prompt.input.rewind
+    expect(prompt.select('What size?', choices, default: 1, quiet: true)).to eq(1)
+    expect(prompt.output.string).to eq([
+      "\e[?25lWhat size? \e[90m(Use #{up_down} arrow keys, press Enter to select)\e[0m\n",
+      "\e[32m#{symbols[:marker]} large\e[0m\n",
+      "  medium\n",
+      "  small",
+      "\e[2K\e[1G\e[1A" * 3,
+      "\e[2K\e[1G",
+      "\e[?25h"
+    ].join)
+  end
+
   it "sets choice name through DSL" do
     prompt.input << " "
     prompt.input.rewind

--- a/spec/unit/select_spec.rb
+++ b/spec/unit/select_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe TTY::Prompt, '#select' do
   end
 
   it "sets choice name and value" do
-    choices = {large: 1, medium: 2, small: 3}
+    choices = { large: 1, medium: 2, small: 3 }
     prompt.input << " "
     prompt.input.rewind
     expect(prompt.select('What size?', choices, default: 1)).to eq(1)
@@ -105,7 +105,7 @@ RSpec.describe TTY::Prompt, '#select' do
   end
 
   it "obeys quiet mode" do
-    choices = {large: 1, medium: 2, small: 3}
+    choices = { large: 1, medium: 2, small: 3 }
     prompt.input << " "
     prompt.input.rewind
     expect(prompt.select('What size?', choices, default: 1, quiet: true)).to eq(1)
@@ -114,6 +114,26 @@ RSpec.describe TTY::Prompt, '#select' do
       "\e[32m#{symbols[:marker]} large\e[0m\n",
       "  medium\n",
       "  small",
+      "\e[2K\e[1G\e[1A" * 3,
+      "\e[2K\e[1G",
+      "\e[?25h"
+    ].join)
+  end
+
+  it "sets quiet mode through DSL" do
+    prompt.input << " "
+    prompt.input.rewind
+    expect(prompt.select('What size?') do |q|
+           q.choice "Large"
+           q.choice "Medium"
+           q.choice "Small"
+           q.quiet true
+    end).to eq("Large")
+    expect(prompt.output.string).to eq([
+      "\e[?25lWhat size? \e[90m(Use #{up_down} arrow keys, press Enter to select)\e[0m\n",
+      "\e[32m#{symbols[:marker]} Large\e[0m\n",
+      "  Medium\n",
+      "  Small",
       "\e[2K\e[1G\e[1A" * 3,
       "\e[2K\e[1G",
       "\e[?25h"

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -36,6 +36,29 @@ RSpec.describe TTY::Prompt, '#slider' do
     ].join)
   end
 
+  it "specifies quiet mode through DSL" do
+    prompt.input << "\r"
+    prompt.input.rewind
+    value = prompt.slider("What size?") do |slider|
+              slider.quiet true
+              slider.default 6
+              slider.min 0
+              slider.max 20
+              slider.step 2
+              slider.format "|:slider| %d%%"
+            end
+    expect(value).to eq(6)
+    expect(prompt.output.string).to eq([
+      "\e[?25lWhat size? ",
+      symbols[:pipe] + symbols[:line] * 3,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      "#{symbols[:line] * 7 + symbols[:pipe]} 6%",
+      "\n\e[90m(Use arrow keys, press Enter to select)\e[0m",
+      "\e[2K\e[1G\e[1A\e[2K\e[1G",
+      "\e[?25h"
+    ].join)
+  end
+
   it "specifies default value" do
     prompt.input << "\r"
     prompt.input.rewind

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe TTY::Prompt, '#slider' do
   it "specifies ranges & step" do
     prompt.input << "\r"
     prompt.input.rewind
-    expect(prompt.slider('What size?', min: 32, max: 54, step: 2)).to eq(44)
+    expect(prompt.slider("What size?", min: 32, max: 54, step: 2)).to eq(44)
     expect(prompt.output.string).to eq([
       "\e[?25lWhat size? ",
       symbols[:line] * 6,
@@ -24,7 +24,7 @@ RSpec.describe TTY::Prompt, '#slider' do
   it "obeys quiet mode" do
     prompt.input << "\r"
     prompt.input.rewind
-    expect(prompt.slider('What size?', min: 32, max: 54, step: 2, quiet: true)).to eq(44)
+    expect(prompt.slider("What size?", min: 32, max: 54, step: 2, quiet: true)).to eq(44)
     expect(prompt.output.string).to eq([
       "\e[?25lWhat size? ",
       symbols[:line] * 6,
@@ -32,14 +32,14 @@ RSpec.describe TTY::Prompt, '#slider' do
       "#{symbols[:line] * 5} 44",
       "\n\e[90m(Use arrow keys, press Enter to select)\e[0m",
       "\e[2K\e[1G\e[1A\e[2K\e[1G",
-	  "\e[?25h"
+      "\e[?25h"
     ].join)
   end
 
   it "specifies default value" do
     prompt.input << "\r"
     prompt.input.rewind
-    expect(prompt.slider('What size?', min: 32, max: 54, step: 2, default: 38)).to eq(38)
+    expect(prompt.slider("What size?", min: 32, max: 54, step: 2, default: 38)).to eq(38)
     expect(prompt.output.string).to eq([
       "\e[?25lWhat size? ",
       symbols[:line] * 3,
@@ -54,7 +54,7 @@ RSpec.describe TTY::Prompt, '#slider' do
   it "specifies range through DSL" do
     prompt.input << "\r"
     prompt.input.rewind
-    value = prompt.slider('What size?') do |range|
+    value = prompt.slider("What size?") do |range|
               range.default 6
               range.min 0
               range.max 20
@@ -77,7 +77,7 @@ RSpec.describe TTY::Prompt, '#slider' do
     prompt.input << "\r"
     prompt.input.rewind
     options = {active_color: :red, help_color: :cyan}
-    expect(prompt.slider('What size?', options)).to eq(5)
+    expect(prompt.slider("What size?", options)).to eq(5)
     expect(prompt.output.string).to eq([
       "\e[?25lWhat size? ",
       symbols[:line] * 5,
@@ -97,7 +97,7 @@ RSpec.describe TTY::Prompt, '#slider' do
         prompt.trigger(:keyright)
       end
     end
-    res = prompt.slider('What size?', min: 0, max: 10, step: 1, default: 10)
+    res = prompt.slider("What size?", min: 0, max: 10, step: 1, default: 10)
     expect(res).to eq(10)
     expect(prompt.output.string).to eq([
       "\e[?25lWhat size? ",
@@ -121,7 +121,7 @@ RSpec.describe TTY::Prompt, '#slider' do
     prompt.input << "\r"
     prompt.input.rewind
 
-    expect(prompt.slider('What size?', min: 32, max: 54, step: 2)).to eq(44)
+    expect(prompt.slider("What size?", min: 32, max: 54, step: 2)).to eq(44)
 
     expect(prompt.output.string).to eq([
       "\e[?25lWhat size? ",
@@ -139,7 +139,7 @@ RSpec.describe TTY::Prompt, '#slider' do
     prompt.input << "\r"
     prompt.input.rewind
 
-    answer = prompt.slider('What size?', min: 32, max: 54, step: 2) do |range|
+    answer = prompt.slider("What size?", min: 32, max: 54, step: 2) do |range|
       range.symbols bullet: 'x', line: '_'
     end
 

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe TTY::Prompt, '#slider' do
     ].join)
   end
 
+  it "obeys quiet mode" do
+    prompt.input << "\r"
+    prompt.input.rewind
+    expect(prompt.slider('What size?', min: 32, max: 54, step: 2, quiet: true)).to eq(44)
+    expect(prompt.output.string).to eq([
+      "\e[?25lWhat size? ",
+      symbols[:line] * 6,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      "#{symbols[:line] * 5} 44",
+      "\n\e[90m(Use arrow keys, press Enter to select)\e[0m",
+      "\e[2K\e[1G\e[1A\e[2K\e[1G",
+	  "\e[?25h"
+    ].join)
+  end
+
   it "specifies default value" do
     prompt.input << "\r"
     prompt.input.rewind

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -44,6 +44,17 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
+    it 'obeys quiet mode' do
+      prompt.input << "\r"
+      prompt.input.rewind
+      expect(prompt.yes?("Are you a human?", quiet: true)).to eq(true)
+      expect(prompt.output.string).to eq([
+        "Are you a human? \e[90m(Y/n)\e[0m ",
+        "\e[2K\e[1GAre you a human? \e[90m(Y/n)\e[0m \n",
+        "\e[1A\e[2K\e[1G"
+      ].join)
+    end
+
     it 'changes default' do
       prompt.input << "\n"
       prompt.input.rewind

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe TTY::Prompt, 'confirmation' do
 
   subject(:prompt) { TTY::TestPrompt.new }
 
-  context '#yes?' do
-    it 'agrees with question' do
+  context "#yes?" do
+    it "agrees with question" do
       prompt.input << 'yes'
       prompt.input.rewind
       expect(prompt.yes?("Are you a human?")).to eq(true)
@@ -19,7 +19,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it 'disagrees with question' do
+    it "disagrees with question" do
       prompt.input << 'no'
       prompt.input.rewind
       expect(prompt.yes?("Are you a human?")).to eq(false)
@@ -32,7 +32,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it 'assumes default true' do
+    it "assumes default true" do
       prompt.input << "\r"
       prompt.input.rewind
       expect(prompt.yes?("Are you a human?")).to eq(true)
@@ -44,7 +44,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it 'obeys quiet mode' do
+    it "obeys quiet mode" do
       prompt.input << "\r"
       prompt.input.rewind
       expect(prompt.yes?("Are you a human?", quiet: true)).to eq(true)
@@ -55,7 +55,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it 'changes default' do
+    it "changes default" do
       prompt.input << "\n"
       prompt.input.rewind
       expect(prompt.yes?("Are you a human?", default: false)).to eq(false)
@@ -164,8 +164,8 @@ RSpec.describe TTY::Prompt, 'confirmation' do
     end
   end
 
-  context '#no?' do
-    it 'agrees with question' do
+  context "#no?" do
+    it "agrees with question" do
       prompt.input << 'no'
       prompt.input.rewind
       expect(prompt.no?("Are you a human?")).to eq(true)
@@ -178,7 +178,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it 'disagrees with question' do
+    it "disagrees with question" do
       prompt.input << 'yes'
       prompt.input.rewind
       expect(prompt.no?("Are you a human?")).to eq(false)
@@ -192,7 +192,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it 'assumes default false' do
+    it "assumes default false" do
       prompt.input << "\r"
       prompt.input.rewind
       expect(prompt.no?("Are you a human?")).to eq(true)
@@ -204,7 +204,7 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
-    it 'changes default' do
+    it "changes default" do
       prompt.input << "\r"
       prompt.input.rewind
       expect(prompt.no?("Are you a human?", default: true)).to eq(false)


### PR DESCRIPTION
### Describe the change

Hi Piotr, loving the libraries! I wanted a way to make a menu system using `Prompt#select` without it leaving the 'breadcrumb trail' of all the previous selections. For example, before:

```
$ # https://gist.github.com/slowbro/c4c1fbb9f972117079a117ea5d19dc17
$ ruby ./example.rb 
Really Cool Menu Coolness Status
Coolness Status Back
Really Cool Menu Manage Coolness
Coolness is at 0.
Manage Add coolness
Coolness is at 1.
Manage Add coolness
Coolness is at 2.
Manage 
  1. Add coolness
  2. Back
_ 3. Exit

```

It's a little hard to see what's going on (and all the terminal recording software I tried did not like all the line-clearing..) - but every time a line-item is selected, a new 'breadcrumb' is added - i.e. at the root, "Really Cool Menu", upon selecting "Coolness Status", a line is left behind: "Really Cool Menu Coolness Status"

Compare that to the version with `:quiet`:

```
$ # https://gist.github.com/slowbro/8517a8e04c41719edcee821f823d351c
$ ruby ./example-quiet.rb                                                                                                                                                                            
Coolness is at 2.
Manage 
  1. Add coolness
  2. Back
_ 3. Exit
```

I did the same exact keystrokes - into status, back, into manage, add twice. But the output is a lot cleaner!

This also applies to a number of other classes:

- slider
- question (and derivatives)
- enum_list
- expander
- mask
- yes

I hope this is a desirable change!

Other minor changes:
- Added vim modeline to lib/*
- Updated some confusing/broken docs
- misc formatting fixes

### Why are we doing this?
I really want to be able to have a clean menu system using tty-prompt :)

### Benefits
Broader customization will expand usage possibility.

### Drawbacks
None that I can see - It's a new feature that should not overlap with anything.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
