### PR TITLE
[Resolves #109] Choice#from doesn't differentiate between nil and false

### DIFF
--- a/lib/tty/prompt/choice.rb
+++ b/lib/tty/prompt/choice.rb
@@ -35,7 +35,7 @@ module TTY
           if name.is_a?(Hash)
             convert_hash(name)
           else
-            new(name.to_s, value || name.to_s, options || {})
+            new(name.to_s, (value.nil? ? name.to_s : value), options || {})
           end
         when Hash
           convert_hash(val)

--- a/spec/unit/choice/from_spec.rb
+++ b/spec/unit/choice/from_spec.rb
@@ -34,6 +34,24 @@ RSpec.describe TTY::Prompt::Choice, '#from' do
     expect(choice.value).to eq(1)
   end
 
+  it "creates choice from array with false" do
+    expected_choice = described_class.new('large', false)
+    choice = described_class.from([:large, false])
+
+    expect(choice).to eq(expected_choice)
+    expect(choice.name).to eq('large')
+    expect(choice.value).to eq(false)
+  end
+
+  it "defaults value to name if value is nil" do
+    expected_choice = described_class.new('large', 'large')
+    choice = described_class.from([:large, nil])
+
+    expect(choice).to eq(expected_choice)
+    expect(choice.name).to eq('large')
+    expect(choice.value).to eq('large')
+  end
+
   it "creates choice from hash value" do
     expected_choice = described_class.new('large', 1)
     choice = described_class.from({large: 1})


### PR DESCRIPTION
### Describe the change
Fixes #109 

### Why are we doing this?
Allow select options to be 'false', instead of defaulting to the name.

### Benefits
Allows differentiation between `nil` and `false` when doing List#choice(Array)

### Drawbacks
None that I can think of.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
