### PR TITLE
fix #106 - yes? and no? shouldn't raise an exception on invalid/blank input

### DIFF
--- a/lib/tty/prompt/confirm_question.rb
+++ b/lib/tty/prompt/confirm_question.rb
@@ -85,21 +85,30 @@ module TTY
 
       protected
 
+      # Decide how to handle input from user
+      #
+      # @api private
+      def process_input(question)
+        @input = read_input(question)
+        if Utils.blank?(@input)
+          @input = default ? positive : negative
+        end
+        @evaluator.(@input)
+      end
+
       # @api private
       def setup_defaults
+        @convert = conversion
         return if suffix? && positive?
 
         if suffix? && (!positive? || !negative?)
           parts = @suffix.split('/')
           @positive = parts[0]
           @negative = parts[1]
-          @convert = conversion
         elsif !suffix? && positive?
           @suffix = create_suffix
-          @convert = conversion
         else
           create_default_labels
-          @convert = :bool
         end
       end
 
@@ -108,6 +117,8 @@ module TTY
         @suffix   = default ? 'Y/n' : 'y/N'
         @positive = default ? 'Yes' : 'yes'
         @negative = default ? 'no' : 'No'
+        @validation = /^(y(es)?|no?)$/i
+        @messages[ :valid? ] = "Invalid input."
       end
 
       # @api private

--- a/lib/tty/prompt/confirm_question.rb
+++ b/lib/tty/prompt/confirm_question.rb
@@ -93,7 +93,7 @@ module TTY
         if Utils.blank?(@input)
           @input = default ? positive : negative
         end
-        @evaluator.(@input)
+        @evaluator.call(@input)
       end
 
       # @api private
@@ -118,7 +118,7 @@ module TTY
         @positive = default ? 'Yes' : 'yes'
         @negative = default ? 'no' : 'No'
         @validation = /^(y(es)?|no?)$/i
-        @messages[ :valid? ] = "Invalid input."
+        @messages[:valid?] = "Invalid input."
       end
 
       # @api private

--- a/spec/unit/yes_no_spec.rb
+++ b/spec/unit/yes_no_spec.rb
@@ -32,6 +32,23 @@ RSpec.describe TTY::Prompt, 'confirmation' do
       ].join)
     end
 
+    it 'warns about invalid entry when using defaults' do
+      prompt.input << "test"
+      prompt.input.rewind
+      prompt.yes?("Are you a human?")
+      expect(prompt.output.string).to eq([
+        "Are you a human? \e[90m(Y/n)\e[0m ",
+        "\e[2K\e[1GAre you a human? \e[90m(Y/n)\e[0m t",
+        "\e[2K\e[1GAre you a human? \e[90m(Y/n)\e[0m te",
+        "\e[2K\e[1GAre you a human? \e[90m(Y/n)\e[0m tes",
+        "\e[2K\e[1GAre you a human? \e[90m(Y/n)\e[0m test",
+        "\e[31m>>\e[0m Invalid input.\e[1A",
+        "\e[2K\e[1GAre you a human? \e[90m(Y/n)\e[0m ",
+        "\e[2K\e[1G\e[1A\e[2K\e[1G",
+        "Are you a human? \e[32mYes\e[0m\n"
+      ].join)
+    end
+
     it 'assumes default true' do
       prompt.input << "\r"
       prompt.input.rewind
@@ -178,6 +195,23 @@ RSpec.describe TTY::Prompt, 'confirmation' do
         "\e[2K\e[1GAre you a human? \e[90m(y/N)\e[0m yes",
         "\e[1A\e[2K\e[1G",
         "Are you a human? \e[32myes\e[0m\n"
+      ].join)
+    end
+
+    it 'warns about invalid entry when using defaults' do
+      prompt.input << "test"
+      prompt.input.rewind
+      prompt.no?("Are you a human?")
+      expect(prompt.output.string).to eq([
+        "Are you a human? \e[90m(y/N)\e[0m ",
+        "\e[2K\e[1GAre you a human? \e[90m(y/N)\e[0m t",
+        "\e[2K\e[1GAre you a human? \e[90m(y/N)\e[0m te",
+        "\e[2K\e[1GAre you a human? \e[90m(y/N)\e[0m tes",
+        "\e[2K\e[1GAre you a human? \e[90m(y/N)\e[0m test",
+        "\e[31m>>\e[0m Invalid input.\e[1A",
+        "\e[2K\e[1GAre you a human? \e[90m(y/N)\e[0m ",
+        "\e[2K\e[1G\e[1A\e[2K\e[1G",
+        "Are you a human? \e[32mNo\e[0m\n"
       ].join)
     end
 


### PR DESCRIPTION
### Describe the change
Fixes #106 by adding a default validator and message:

```
+               @validation = /^(y(es)?|no?)$/i
+               @messages[ :valid? ] = "Invalid input."
```

Also, overrides Question's `process_input` to insert the default `positive` or `negative` string on blank input.

### Why are we doing this?
Fixes unhandled exceptions in yes?/no? when a user inputs unexpected text:

```
[4] pry(main)> p.yes?( "Yes?" )
Yes? (Y/n) b
TTY::Prompt::ConversionError: 'b' could not be converted from `string` into `boolean` 
from /usr/home/kschiesser/.rvm/gems/ruby-2.6.3@laika/gems/tty-prompt-0.19.0/lib/tty/prompt/converters.rb:23:in `rescue in on_error'
```

vs

```
[3] pry(main)> p.yes?( "Yes?" )
Yes? (Y/n) b
>> Invalid input.
```

### Benefits
Fixes a couple unhandled exceptions.

### Drawbacks
I stopped using Necromancer's `:bool` conversion for this - it seemed unnecessary, given the already existent `conversion` function plus the validation. Feel free to override me there :)

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
