### PR TITLE
Use set help_color in multi_select prompt

### DIFF
--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -84,7 +84,7 @@ module TTY
       #
       # @api private
       def render_header
-        instructions = @prompt.decorate(help, :bright_black)
+        instructions = @prompt.decorate(help, @help_color)
         max_suffix = @max ? max_help : ""
 
         if @done && @echo

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -274,17 +274,17 @@ RSpec.describe TTY::Prompt do
     ].join)
   end
 
-  it "changes help text" do
+  it "changes help text and color" do
     prompt = TTY::TestPrompt.new
     choices = %w(vodka beer wine whisky bourbon)
     prompt.input << "\r"
     prompt.input.rewind
-
-    answer = prompt.multi_select("Select drinks?", choices, help: '(Bash keyboard)')
+    options = { help: '(Bash keyboard)', help_color: :cyan }
+    answer = prompt.multi_select("Select drinks?", choices, options)
 
     expect(answer).to eq([])
     expected_output = [
-      "\e[?25lSelect drinks? \e[90m(Bash keyboard)\e[0m\n",
+      "\e[?25lSelect drinks? \e[36m(Bash keyboard)\e[0m\n",
       "#{symbols[:marker]} #{symbols[:radio_off]} vodka\n",
       "  #{symbols[:radio_off]} beer\n",
       "  #{symbols[:radio_off]} wine\n",

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -279,8 +279,8 @@ RSpec.describe TTY::Prompt do
     choices = %w(vodka beer wine whisky bourbon)
     prompt.input << "\r"
     prompt.input.rewind
-    options = { help: '(Bash keyboard)', help_color: :cyan }
-    answer = prompt.multi_select('Select drinks?', choices, options)
+    options = { help: "(Bash keyboard)", help_color: :cyan }
+    answer = prompt.multi_select("Select drinks?", choices, options)
 
     expect(answer).to eq([])
     expected_output = [

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe TTY::Prompt do
     prompt.input << "\r"
     prompt.input.rewind
     options = { help: '(Bash keyboard)', help_color: :cyan }
-    answer = prompt.multi_select("Select drinks?", choices, options)
+    answer = prompt.multi_select('Select drinks?', choices, options)
 
     expect(answer).to eq([])
     expected_output = [


### PR DESCRIPTION
Setting the help color in the prompt initialization or as an option to
the `multi_select` method sets `@help_color`, so we can use that when
printing the help message for `multi_select` prompts.

### Describe the change
Makes multi-select prompt help messages print in the specified color.

### Why are we doing this?
The default help color is invisible with the popular 'solarized' terminal scheme.

### Benefits
The help color can be changed by users of the gem.

### Drawbacks
This only changes one instance of this type of bug.  There are no more for help color but there may be others for active color and error color.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[N/A] Rebased with `master` branch? 
[N/A] Documentation updated?

For #118