### PR TITLE
add example validate via proc to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,12 @@ prompt.ask('What is your username?') do |q|
 end
 ```
 
+```ruby
+prompt.ask('What is your username?') do |q|
+  q.validate { |input| input =~ /^[^\.]+\.[^\.]+/ }
+end
+```
+
 The **TTY::Prompt** comes with built-in validations for `:email` and you can use them directly like so:
 
 ```ruby


### PR DESCRIPTION
### Describe the change
Add an example code snippet to the README.md section 2.1.9.

### Why are we doing this?
Section 2.1.9 mentions that the validate method accepts a Regexp, Proc and Symbol, but until now only provided examples for the Regexp and Symbol.

### Benefits
It would have helped me as a user if it were there when I was looking, as I had to read the code to find details on the Proc approach.

### Drawbacks
None that I am aware of.

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?
