### PR TITLE
Add a :min option to multi_select/multi_list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,7 +1016,7 @@ prompt.multi_select("Select drinks?", choices, min: 3)
 #   ⬢ beer
 #   ⬡ wine
 #   ⬡ wiskey
-# �� ⬡ bourbon
+# ‣ ⬡ bourbon
 ```
 
 #### 2.6.3.5 `:max`

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ Or install it yourself as:
       * [2.6.3.1 :disabled](#2631-disabled)
       * [2.6.3.2 :echo](#2632-echo)
       * [2.6.3.3 :filter](#2633-filter)
-      * [2.6.3.4 :max](#2634-max)
+      * [2.6.3.4 :min](#2634-min)
+      * [2.6.3.5 :max](#2635-max)
     * [2.6.4 enum_select](#264-enum_select)
       * [2.6.4.1 :per_page](#2641-per_page)
       * [2.6.4.1 :disabled](#2641-disabled)
@@ -1002,9 +1003,25 @@ If the user changes or deletes a filter, the choices previously selected remain 
 
 The `filter` option is not compatible with `enum`.
 
-#### 2.6.3.4 `:max`
+#### 2.6.3.4 `:min`
 
-To limit the number of choices an user can select, use `:max` option:
+To force the minimum number of choices an user must select, use the `:min` option:
+
+```ruby
+choices = %w(vodka beer wine whisky bourbon)
+prompt.multi_select("Select drinks?", choices, min: 3)
+# =>
+# Select drinks? (min. 3) vodka, beer
+#   ⬢ vodka
+#   ⬢ beer
+#   ⬡ wine
+#   ⬡ wiskey
+# �� ⬡ bourbon
+```
+
+#### 2.6.3.5 `:max`
+
+To limit the number of choices an user can select, use the `:max` option:
 
 ```ruby
 choices = %w(vodka beer wine whisky bourbon)


### PR DESCRIPTION
### Describe the change
Adds the ability to set a minimum number of items to be selected in a TTY::Prompt.multi_select

### Why are we doing this?
There's a maximum - why not a minimum? I ran into a need for this recently and thought I would add it.

### Benefits
More options!

### Drawbacks
None that I can think of.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
