### PR TITLE
Fix documentation (validation option, slider example)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1315,7 +1315,7 @@ prompt.slider('Volume', max: 100, step: 5, default: 75)
 You can also change the default slider formatting using the `:format`. The value must contain the `:slider` token to show current value and any `sprintf` compatible flag for number display, in our case `%d`:
 
 ```ruby
-prompt.slider('Volume', max: 100, step: 5, default: 75, format: "|:slider| %d%")
+prompt.slider('Volume', max: 100, step: 5, default: 75, format: "|:slider| %d%%")
 # =>
 # Volume |───────────────●──────| 75%
 # (Use arrow keys, press Enter to select)


### PR DESCRIPTION
### Describe the change
Fixes documentation in Readme

### Why are we doing this?
For Sparta!

### Benefits
Functioning examples

### Drawbacks
No puzzle for developers

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally? (there is in fact no test using the validation option opposed to the `#validate` method. should I modify one of the existing or add a new test?)
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?

---

As per [`options.fetch(:validation)`](https://github.com/piotrmurach/tty-prompt/blob/65187af24f89dd15b6c7be67dff2fee381b647e0/lib/tty/prompt/question.rb#L45)

The other example lead to `incomplete format specifier; use %% (double %) instead`