### PR TITLE
Rename validation option to "validate"

### DIFF
--- a/lib/tty/prompt/question.rb
+++ b/lib/tty/prompt/question.rb
@@ -35,23 +35,33 @@ module TTY
       #
       # @api public
       def initialize(prompt, **options)
-        @prompt     = prompt
-        @prefix     = options.fetch(:prefix) { @prompt.prefix }
-        @default    = options.fetch(:default) { UndefinedSetting }
-        @required   = options.fetch(:required) { false }
-        @echo       = options.fetch(:echo) { true }
-        @in         = options.fetch(:in) { UndefinedSetting }
-        @modifier   = options.fetch(:modifier) { [] }
-        @validation = options.fetch(:validate) { UndefinedSetting }
-        @convert    = options.fetch(:convert) { UndefinedSetting }
+        # Option deprecation
+        if options.fetch(:validation) { nil }
+          warn <<-MSG.gsub(/[[:space:]]+/, " ").strip
+            [DEPRECATION] The `:validation` option is deprecated and
+            will be removed in a future release of tty-prompt
+            (use functionally identical `:validate` instead)
+          MSG
+          options[:validate] = options.fetch(:validation)
+        end
+
+        @prompt       = prompt
+        @prefix       = options.fetch(:prefix) { @prompt.prefix }
+        @default      = options.fetch(:default) { UndefinedSetting }
+        @required     = options.fetch(:required) { false }
+        @echo         = options.fetch(:echo) { true }
+        @in           = options.fetch(:in) { UndefinedSetting }
+        @modifier     = options.fetch(:modifier) { [] }
+        @validation   = options.fetch(:validate) { UndefinedSetting }
+        @convert      = options.fetch(:convert) { UndefinedSetting }
         @active_color = options.fetch(:active_color) { @prompt.active_color }
-        @help_color = options.fetch(:help_color) { @prompt.help_color }
-        @error_color = options.fetch(:error_color) { :red }
-        @value      = options.fetch(:value) { UndefinedSetting }
-        @messages   = Utils.deep_copy(options.fetch(:messages) { { } })
-        @done       = false
+        @help_color   = options.fetch(:help_color) { @prompt.help_color }
+        @error_color  = options.fetch(:error_color) { :red }
+        @value        = options.fetch(:value) { UndefinedSetting }
+        @messages     = Utils.deep_copy(options.fetch(:messages) { { } })
+        @done         = false
         @first_render = true
-        @input      = nil
+        @input        = nil
 
         @evaluator = Evaluator.new(self)
 

--- a/lib/tty/prompt/question.rb
+++ b/lib/tty/prompt/question.rb
@@ -42,7 +42,7 @@ module TTY
         @echo       = options.fetch(:echo) { true }
         @in         = options.fetch(:in) { UndefinedSetting }
         @modifier   = options.fetch(:modifier) { [] }
-        @validation = options.fetch(:validation) { UndefinedSetting }
+        @validation = options.fetch(:validate) { UndefinedSetting }
         @convert    = options.fetch(:convert) { UndefinedSetting }
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color = options.fetch(:help_color) { @prompt.help_color }

--- a/lib/tty/prompt/question.rb
+++ b/lib/tty/prompt/question.rb
@@ -36,13 +36,9 @@ module TTY
       # @api public
       def initialize(prompt, **options)
         # Option deprecation
-        if options.fetch(:validation) { nil }
-          warn <<-MSG.gsub(/[[:space:]]+/, " ").strip
-            [DEPRECATION] The `:validation` option is deprecated and
-            will be removed in a future release of tty-prompt
-            (use functionally identical `:validate` instead)
-          MSG
-          options[:validate] = options.fetch(:validation)
+        if options[:validation]
+          warn "[DEPRECATION] The `:validation` option is deprecated. Use `:validate` instead."
+          options[:validate] = options[:validation]
         end
 
         @prompt       = prompt

--- a/spec/unit/question/validate_spec.rb
+++ b/spec/unit/question/validate_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe TTY::Prompt::Question, '#validate' do
 
     expect do
       prompt.ask('What is your email?', validation: :email)
-    end.to output(/`:validation` option is deprecated/).to_stderr
+    end.to output("[DEPRECATION] The `:validation` option is deprecated. Use `:validate` instead.\n").to_stderr
   end
 
   it "provides default error message for wrong input" do

--- a/spec/unit/question/validate_spec.rb
+++ b/spec/unit/question/validate_spec.rb
@@ -45,6 +45,15 @@ RSpec.describe TTY::Prompt::Question, '#validate' do
     expect(answer).to eq('piotr@example.com')
   end
 
+  it 'deprecates :validation option' do
+    prompt.input << 'piotr@example.com'
+    prompt.input.rewind
+
+    expect do
+      prompt.ask('What is your email?', validation: :email)
+    end.to output(/`:validation` option is deprecated/).to_stderr
+  end
+
   it "provides default error message for wrong input" do
     prompt.input << "wrong\np@m.com\n"
     prompt.input.rewind

--- a/spec/unit/question/validate_spec.rb
+++ b/spec/unit/question/validate_spec.rb
@@ -83,8 +83,7 @@ RSpec.describe TTY::Prompt::Question, '#validate' do
     prompt.input << "wrong\np@m.com"
     prompt.input.rewind
 
-    answer = prompt.ask('What is your email?') do |q|
-      q.validate :email
+    answer = prompt.ask('What is your email?', validate: :email) do |q|
       q.messages[:valid?] = 'Not an email!'
     end
 


### PR DESCRIPTION
### Describe the change
Renames validation option to reflect method name

### Why are we doing this?
Consistency (well actually it's now the only option to not reflect the instance variable but what can you do)

### Benefits
Consistency

### Drawbacks
Possible implementation break for people already using `validation` as option

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally? (I borrowed one of the negative tests, guess that should be alright?)
[X] Code style checked?
[X] Rebased with `master` branch? (that's what I get for not using a feature branch earlier, hell)
[X] Documentation updated?
