### PR TITLE
[feature] Allow slider format proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1330,6 +1330,16 @@ prompt.slider("Volume", max: 10, step: 0.5, default: 5, format: "|:slider| %.1f"
 # (Use arrow keys, press Enter to select)
 ```
 
+You can alternatively provide a proc/lambda to customize your formatting even further:
+
+```ruby
+slider_format = -> (slider, value) { "|#{slider}| #{value.zero? ? "muted" : "%.1f"}" % value }
+prompt.slider("Volume", max: 10, step: 0.5, default: 0, format: slider_format)
+# =>
+# Volume |●─────────────────────| muted
+# (Use arrow keys, press Enter to select)
+```
+
 If you wish to change the slider handle and the slider range display use `:symbols` option:
 
 ```ruby

--- a/lib/tty/prompt/slider.rb
+++ b/lib/tty/prompt/slider.rb
@@ -191,8 +191,13 @@ module TTY
         slider = (@symbols[:line] * @active) +
                  @prompt.decorate(@symbols[:bullet], @active_color) +
                  (@symbols[:line] * (range.size - @active - 1))
-        value = " #{range[@active]}"
-        @format.gsub(':slider', slider) % [value]
+        value = range[@active]
+        case @format
+        when Proc
+          @format.call(slider, value)
+        else
+          @format.gsub(':slider', slider) % [value]
+        end
       end
     end # Slider
   end # Prompt

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -58,6 +58,27 @@ RSpec.describe TTY::Prompt, '#slider' do
     ].join)
   end
 
+  it "formats via proc" do
+    prompt.input << "\r"
+    prompt.input.rewind
+    value = prompt.slider('What size?') do |range|
+              range.default 6
+              range.max 20
+              range.step 2
+              range.format ->(slider, value) { "|#{slider}| %d%%" % value }
+            end
+    expect(value).to eq(6)
+    expect(prompt.output.string).to eq([
+      "\e[?25lWhat size? ",
+      symbols[:pipe] + symbols[:line] * 3,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      "#{symbols[:line] * 7 + symbols[:pipe]} 6%",
+      "\n\e[90m(Use arrow keys, press Enter to select)\e[0m",
+      "\e[2K\e[1G\e[1A\e[2K\e[1G",
+      "What size? \e[32m6\e[0m\n\e[?25h"
+    ].join)
+  end
+
   it "changes display colors" do
     prompt.input << "\r"
     prompt.input.rewind


### PR DESCRIPTION
### Describe the change
Allow slider format to be a proc

### Why are we doing this?
features

### Benefits
flexibility

### Drawbacks
None? Why exactly was `value` casted to a string with a space there? It doesn't do anything when using a `%d` or `%f` so I removed it for both 🧐

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?

Hey again, while [bastardizing](https://user-images.githubusercontent.com/218011/77568467-f15add80-6ec8-11ea-8143-18d45ef090b3.png) your library I thought this might be useful to others. select with sliders anyone?

