### PR TITLE
Fix ':disabled' example syntax error in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ The `:disabled` key indicates to display a choice as currently unavailable to se
 ```ruby
 choices = [
   {name: 'small', value: 1},
-  {name: 'medium', value: 2, disabled: '(out of stock)'}
+  {name: 'medium', value: 2, disabled: '(out of stock)'},
   {name: 'large', value: 3}
 ]
 ```


### PR DESCRIPTION
### Describe the change
Fix syntax error in [:disabled example](https://github.com/piotrmurach/tty-prompt/blob/master/README.md#2611-disabled).

### Why are we doing this?
To make the example workable.

### Benefits
The example will to work.

### Drawbacks
N/A

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally?(Fix README only)
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?
