### PR TITLE
Preserve initial order of selected choices despite the order they were selected in

### DIFF
--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -60,7 +60,7 @@ module TTY
         else
           return if @max && @selected.size >= @max
           @selected << active_choice
-          @selected.sort_by! { |choice| @choices.index(choice) }
+          @selected = @choices.to_ary & @selected
         end
       end
 

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -60,6 +60,7 @@ module TTY
         else
           return if @max && @selected.size >= @max
           @selected << active_choice
+          @selected.sort_by! { |choice| @choices.index(choice) }
         end
       end
 


### PR DESCRIPTION
### Describe the change

Preserve initial order of selected choices despite the order they were selected in

### Why are we doing this?

Examplary motivation: I'm writing a deployment script which at one point asks the user which commits to cherry-pick for further deployment. The order of the commits is paramount. 

### Benefits

`multi_select` will be a solution to cases where order of chosen items is crucial

### Drawbacks

Will have to maintain the option in future

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[rubocup reports 2000+ offenses, but they don't seem to be related to this PR] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?
