### PR TITLE
Add `Choice#index` and `Choice#<=>`

### DIFF
--- a/lib/tty/prompt/choice.rb
+++ b/lib/tty/prompt/choice.rb
@@ -2,10 +2,12 @@
 
 module TTY
   class Prompt
-    # An immutable representation of a single choice option from select menu
+    # A representation of a single choice option from select menu
     #
     # @api public
     class Choice
+      attr_accessor :index
+
       # Create choice from value
       #
       # @examples
@@ -26,7 +28,7 @@ module TTY
       # @return [Choice]
       #
       # @api public
-      def self.from(val)
+      def self.from(val, index: nil)
         case val
         when Choice
           val
@@ -41,6 +43,8 @@ module TTY
           convert_hash(val)
         else
           new(val, val)
+        end.tap do |choice|
+          choice.index = index
         end
       end
 
@@ -80,7 +84,6 @@ module TTY
         @value = value
         @key   = options[:key]
         @disabled = options[:disabled].nil? ? false : options[:disabled]
-        freeze
       end
 
       # Check if this choice is disabled
@@ -114,6 +117,17 @@ module TTY
         name == other.name &&
         value == other.value &&
         key == other.key
+      end
+
+      # Object spaceship operator.
+      # Returns negative number if the index of the left operand is lower.
+      # Returns positive number if the index of the right operand is lower
+      #
+      # @return [Fixnum]
+      #
+      # @api public
+      def <=>(other)
+        index <=> other.index
       end
 
       # Object string representation

--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -33,8 +33,9 @@ module TTY
       #
       # @api public
       def initialize(choices = [])
-        @choices = choices.map do |choice|
-          Choice.from(choice)
+        @choices = []
+        choices.map do |choice|
+          self << choice
         end
       end
 
@@ -54,10 +55,10 @@ module TTY
       #   the choice to add
       #
       # @api public
-      def <<(choice)
-        tap do
-          choices << Choice.from(choice)
-        end
+      def <<(val)
+        choice = Choice.from val, index: choices.size
+        choices << choice
+        self
       end
 
       # Access choice by index

--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -13,16 +13,6 @@ module TTY
       include Enumerable
       extend Forwardable
 
-      # The actual collection choices
-      #
-      # @return [Array[Choice]]
-      #
-      # @api public
-      attr_reader :choices
-
-      def_delegators :choices, :length, :size, :to_ary, :empty?,
-                               :values_at, :index
-
       # Convenience for creating choices
       #
       # @param [Array[Object]] choices
@@ -65,7 +55,9 @@ module TTY
       #
       # @api public
       def <<(choice)
-        choices << Choice.from(choice)
+        tap do
+          choices << Choice.from(choice)
+        end
       end
 
       # Access choice by index
@@ -106,6 +98,13 @@ module TTY
       def find_by(attr, value)
         find { |choice| choice.public_send(attr) == value }
       end
+
+      protected
+
+      attr_reader :choices
+
+      def_delegators :choices, :length, :size, :empty?,
+                     :values_at, :index, :==
     end # Choices
   end # Prompt
 end # TTY

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -60,7 +60,7 @@ module TTY
         else
           return if @max && @selected.size >= @max
           @selected << active_choice
-          @selected.sort_by! { |choice| @choices.index(choice) }
+          @selected.sort!
         end
       end
 

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -60,6 +60,7 @@ module TTY
         else
           return if @max && @selected.size >= @max
           @selected << active_choice
+          @selected.sort_by! { |choice| @choices.index(choice) }
         end
       end
 

--- a/spec/unit/choice/compare_spec.rb
+++ b/spec/unit/choice/compare_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Prompt::Choice, "#<=>" do
+  let(:choices) { TTY::Prompt::Choices[:foo, :bar] }
+
+  it "returns negative when the index of the left operand is lower" do
+    expect(choices[0] <=> choices[1]).to be_negative
+  end
+
+  it "returns positive when the index of the right operand is lower" do
+    expect(choices[1] <=> choices[0]).to be_positive
+  end
+
+  it "allows to sort instances of Choice in any arbitrary array" do
+    arbitrary_array = choices.each.to_a
+
+    expect(arbitrary_array.reverse.sort).to eq(arbitrary_array)
+  end
+end

--- a/spec/unit/choice/from_spec.rb
+++ b/spec/unit/choice/from_spec.rb
@@ -127,4 +127,14 @@ RSpec.describe TTY::Prompt::Choice, '#from' do
     expect(choice.value).to eq(size)
     expect(choice.disabled?).to eq(false)
   end
+
+  it "sets an index to the instance if given" do
+    [
+      described_class.new(:foo, 1),
+      [:foo, 1],
+      { name: :foo, value: 1 }
+    ].each do |obj|
+      expect(described_class.from(obj, index: 42).index).to eq 42
+    end
+  end
 end

--- a/spec/unit/choices/add_spec.rb
+++ b/spec/unit/choices/add_spec.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
 RSpec.describe TTY::Prompt::Choices, '#<<' do
+  let(:choices) { described_class.new }
+
   it "adds choice to collection" do
-    choices = described_class.new
     expect(choices).to be_empty
     choice = TTY::Prompt::Choice.from([:label, 1])
     choices << [:label, 1]
     expect(choices.size).to eq(1)
     expect(choices).to eq([choice])
+  end
+
+  it "assigns an index to the added choice" do
+    choices << :foo << :bar
+    expect(choices.map(&:index)).to eq [0, 1]
   end
 end

--- a/spec/unit/choices/add_spec.rb
+++ b/spec/unit/choices/add_spec.rb
@@ -7,6 +7,6 @@ RSpec.describe TTY::Prompt::Choices, '#<<' do
     choice = TTY::Prompt::Choice.from([:label, 1])
     choices << [:label, 1]
     expect(choices.size).to eq(1)
-    expect(choices.to_ary).to eq([choice])
+    expect(choices).to eq([choice])
   end
 end

--- a/spec/unit/choices/new_spec.rb
+++ b/spec/unit/choices/new_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe TTY::Prompt::Choices, '.new' do
     choice_1 = TTY::Prompt::Choice.from(:label1)
     choice_2 = TTY::Prompt::Choice.from(:label2)
     collection = described_class[:label1, :label2]
-    expect(collection.choices).to eq([choice_1, choice_2])
+    expect(collection).to eq([choice_1, choice_2])
   end
 end

--- a/spec/unit/choices/new_spec.rb
+++ b/spec/unit/choices/new_spec.rb
@@ -1,10 +1,16 @@
 # frozen_string_literal: true
 
 RSpec.describe TTY::Prompt::Choices, '.new' do
-  it "creates choices collection" do
-    choice_1 = TTY::Prompt::Choice.from(:label1)
-    choice_2 = TTY::Prompt::Choice.from(:label2)
-    collection = described_class[:label1, :label2]
-    expect(collection).to eq([choice_1, choice_2])
+  let(:choice_1) { TTY::Prompt::Choice.from(:label1) }
+  let(:choice_2) { TTY::Prompt::Choice.from(:label2) }
+
+  subject { described_class[:label1, :label2] }
+
+  it "creates choices collection with proper indices" do
+    expect(subject).to eq([choice_1, choice_2])
+  end
+
+  it "assignes proper indices to instances of Choice" do
+    expect(subject.map(&:index)).to eq [0, 1]
   end
 end


### PR DESCRIPTION
### Describe the change

It adds `#index` and `#<=>` methods to `Choice` which makes them sortable inside `Choices`.

### Why are we doing this?

In PR https://github.com/piotrmurach/tty-prompt/pull/141 Piotr suggested

>  I wonder if we could extend the Choice with index attribute or similar and make it comparable. This would simplify and speed up sorting:
> `@selected.sort!`

### Benefits

`@selected.sort_by! { |choice| choices.index(choice) }` can be replaced with `@selected.sort!`

### Drawbacks

* Breaks a promise of immutability of instances of Choice as described in public API
* Breaks backward compatibility by pulling `Choices#choices` (an Array) from the public API to avoid direct addition without setting an index.
* Breaks a convention of `Comparable` mixin which requires coherence of `<=>` and `==` operators.
* Since instances of Choice can be created outside Choices, the former can theoretically be added to more than one Choices which requires additional checks and considerations.
* `Choice#index` is left mutable from the outside (though not in public API)

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?
