### PR TITLE
Add `Choices#enabled`

### DIFF
--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -48,6 +48,13 @@ module TTY
         end
       end
 
+      # Scope of choices which are not disabled
+      #
+      # @api public
+      def enabled
+        reject(&:disabled?)
+      end
+
       # Iterate over all choices in the collection
       #
       # @yield [Choice]

--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -198,9 +198,8 @@ module TTY
             @choices
           else
             filter_value = @filter.join.downcase
-            @filter_cache[filter_value] ||= @choices.select do |choice|
-              !choice.disabled? &&
-                choice.name.downcase.include?(filter_value)
+            @filter_cache[filter_value] ||= @choices.enabled.select do |choice|
+              choice.name.downcase.include?(filter_value)
             end
           end
         else

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -68,7 +68,7 @@ module TTY
       # @api private
       def keyctrl_a(*)
         return if @max && @max < choices.size
-        @selected = choices.select { |choice| !choice.disabled? }
+        @selected = choices.enabled
       end
 
       # Revert currently selected choices when Ctrl+I is pressed
@@ -76,7 +76,7 @@ module TTY
       # @api private
       def keyctrl_r(*)
         return if @max && @max < choices.size
-        @selected = choices.select { |choice| !choice.disabled? } - @selected
+        @selected = choices.enabled - @selected
       end
 
       private

--- a/spec/unit/choices/enabled_spec.rb
+++ b/spec/unit/choices/enabled_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Prompt::Choices, "#enabled" do
+  it "returns only choices which aren't disabled" do
+    enabled_choice = TTY::Prompt::Choice.new :foo, :bar
+    disabled_choice = TTY::Prompt::Choice.new :fizz, :bazz, disabled: true
+
+    choices = described_class[enabled_choice, disabled_choice]
+    expect(choices.enabled).to eq [enabled_choice]
+  end
+end


### PR DESCRIPTION
### Describe the change

Adds a convenient function of `Choices#enabled` as requested in https://github.com/piotrmurach/tty-prompt/pull/142/files#r443211952

### Why are we doing this?

Niceness of this addition has been discovered by accident in https://github.com/piotrmurach/tty-prompt/pull/142

### Benefits

It enriches the public API and makes the code cleaner/more readable.

### Drawbacks

Will have to support it in future as it is a part of public API now

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?
