### PR TITLE
Preserve original choices order in multi_select prompt when selecting

### DIFF
--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -55,6 +55,13 @@ module TTY
         reject(&:disabled?)
       end
 
+      def enabled_indexes
+        each_with_index.reduce([]) do |acc, (choice, idx)|
+          acc << idx unless choice.disabled?
+          acc
+        end
+      end
+
       # Iterate over all choices in the collection
       #
       # @yield [Choice]

--- a/lib/tty/prompt/selected_choices.rb
+++ b/lib/tty/prompt/selected_choices.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module TTY
+  class Prompt
+    # @api private
+    class SelectedChoices
+      include Enumerable
+
+      attr_reader :size
+
+      # Create selected choices
+      #
+      # @param [Array<Choice>] selected
+      # @param [Array<Integer>] indexes
+      #
+      # @api public
+      def initialize(selected = [], indexes = [])
+        @selected = selected
+        @indexes = indexes
+        @size = @selected.size
+      end
+
+      # Clear selected choices
+      #
+      # @api public
+      def clear
+        @indexes.clear
+        @selected.clear
+        @size = 0
+      end
+
+      # Iterate over selected choices
+      #
+      # @api public
+      def each(&block)
+        return to_enum unless block_given?
+        @selected.each(&block)
+      end
+
+      # Insert choice at index
+      #
+      # @param [Integer] index
+      # @param [Choice] choice
+      #
+      # @api public
+      def insert(index, choice)
+        insert_idx = find_index_by { |i| index < @indexes[i] }
+        insert_idx ||= -1
+        @indexes.insert(insert_idx, index)
+        @selected.insert(insert_idx, choice)
+        @size += 1
+        self
+      end
+
+      # Delete choice at index
+      #
+      # @return [Choice]
+      #   the deleted choice
+      #
+      # @api public
+      def delete_at(index)
+        delete_idx = @indexes.each_index.find { |i| index == @indexes[i] }
+        return nil unless delete_idx
+
+        @indexes.delete_at(delete_idx)
+        choice = @selected.delete_at(delete_idx)
+        @size -= 1
+        choice
+      end
+
+      def find_index_by(&search)
+        (0...@size).bsearch(&search)
+      end
+    end # SelectedChoices
+  end # Prompt
+end # TTY

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -437,7 +437,7 @@ RSpec.describe TTY::Prompt do
 
       answer = prompt.multi_select("What number?", choices, default: 2, per_page: 4)
 
-      expect(answer).to eq(["2", "1"])
+      expect(answer).to eq(["1", "2"])
 
       expected_output =
         output_helper("What number?", choices[0..3], "2", ["2"], init: true,
@@ -447,8 +447,8 @@ RSpec.describe TTY::Prompt do
         output_helper("What number?", choices[4..7], "6", ["2"]) +
         output_helper("What number?", choices[3..6], "5", ["2"]) +
         output_helper("What number?", choices[0..3], "1", ["2"]) +
-        output_helper("What number?", choices[0..3], "1", ["2", "1"]) +
-        exit_message("What number?", %w[2 1])
+        output_helper("What number?", choices[0..3], "1", ["1", "2"]) +
+        exit_message("What number?", %w[1 2])
 
       expect(prompt.output.string).to eq(expected_output)
     end
@@ -457,18 +457,19 @@ RSpec.describe TTY::Prompt do
       prompt = TTY::TestPrompt.new
       choices = ("1".."12").to_a
       prompt.on(:keypress) { |e| prompt.trigger(:keyctrl_a) if e.value == "a" }
-      prompt.input << "a" << "\r"
+      prompt.input << "a" << " " << "\r"
       prompt.input.rewind
 
       answer = prompt.multi_select("What number?", choices, per_page: 4)
 
-      expect(answer).to eq(choices)
+      expect(answer).to eq(choices - %w[1])
 
       expected_output =
         output_helper("What number?", choices[0..3], "1", [], init: true,
           hint: "Press #{up_down}/#{left_right} arrow to move, Space/Ctrl+A|R to select (all|rev) and Enter to finish") +
         output_helper("What number?", choices[0..3], "1", choices) +
-        exit_message("What number?", choices)
+        output_helper("What number?", choices[0..3], "1", choices - %w[1]) +
+        exit_message("What number?", choices - %w[1])
 
       expect(prompt.output.string).to eq(expected_output)
     end

--- a/spec/unit/selected_choices_spec.rb
+++ b/spec/unit/selected_choices_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require_relative "../../lib/tty/prompt/selected_choices"
+
+RSpec.describe TTY::Prompt::SelectedChoices do
+  it "inserts choices by the index order" do
+    choices = %w[A B C D E F]
+    selected = described_class.new
+
+    expect(selected.to_a).to eq([])
+    expect(selected.size).to eq(0)
+
+    selected.insert(5, "F")
+    selected.insert(1, "B")
+    selected.insert(3, "D")
+    selected.insert(0, "A")
+    selected.insert(4, "E")
+    selected.insert(2, "C")
+
+    expect(selected.to_a).to eq(choices)
+    expect(selected.size).to eq(6)
+
+    expect(selected.delete_at(3)). to eq("D")
+  end
+
+  it "initializes with selected choices" do
+    choices = %w[A B C D E F]
+    selected = described_class.new(choices, (0...choices.size).to_a)
+
+    expect(selected.to_a).to eq(choices)
+    expect(selected.size).to eq(6)
+
+    choice = selected.delete_at(3)
+    expect(choice).to eq("D")
+
+    expect(selected.to_a).to eq(%w[A B C E F])
+    expect(selected.size).to eq(5)
+  end
+
+  it "inserts and deletes choices" do
+    selected = described_class.new
+
+    selected.insert(5, "F")
+    selected.insert(1, "B")
+    selected.insert(3, "D")
+    selected.insert(0, "A")
+
+    expect(selected.to_a).to eq(%w[A B D F])
+    expect(selected.size).to eq(4)
+
+    choice = selected.delete_at(3)
+    expect(choice).to eq("D")
+    expect(selected.to_a).to eq(%w[A B F])
+    expect(selected.size).to eq(3)
+
+    selected.insert(4, "E")
+    choice = selected.delete_at(-999)
+
+    expect(choice).to eq(nil)
+    expect(selected.to_a).to eq(%w[A B E F])
+    expect(selected.size).to eq(4)
+  end
+
+  it "clears choices" do
+    selected = described_class.new(%w[B D F])
+
+    expect(selected.to_a).to eq(%w[B D F])
+    expect(selected.size).to eq(3)
+
+    selected.clear
+
+    expect(selected.to_a).to eq([])
+    expect(selected.size).to eq(0)
+  end
+end

--- a/spec/unit/selected_choices_spec.rb
+++ b/spec/unit/selected_choices_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "../../lib/tty/prompt/selected_choices"
-
 RSpec.describe TTY::Prompt::SelectedChoices do
   it "inserts choices by the index order" do
     choices = %w[A B C D E F]


### PR DESCRIPTION
Adds `SelectedChoices` class to help keep the original choice order regardless of the selection order in `multi_select` prompt.
