### PR TITLE
Hide underlying `Choices#choices` from public API

### DIFF
--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -13,15 +13,8 @@ module TTY
       include Enumerable
       extend Forwardable
 
-      # The actual collection choices
-      #
-      # @return [Array[Choice]]
-      #
-      # @api public
-      attr_reader :choices
-
       def_delegators :choices, :length, :size, :to_ary, :empty?,
-                               :values_at, :index
+                     :values_at, :index, :==
 
       # Convenience for creating choices
       #
@@ -113,6 +106,16 @@ module TTY
       def find_by(attr, value)
         find { |choice| choice.public_send(attr) == value }
       end
+
+      protected
+
+      # The actual collection choices
+      #
+      # @return [Array[Choice]]
+      #
+      # @api private
+
+      attr_reader :choices
     end # Choices
   end # Prompt
 end # TTY

--- a/spec/unit/choices/new_spec.rb
+++ b/spec/unit/choices/new_spec.rb
@@ -5,6 +5,6 @@ RSpec.describe TTY::Prompt::Choices, '.new' do
     choice_1 = TTY::Prompt::Choice.from(:label1)
     choice_2 = TTY::Prompt::Choice.from(:label2)
     collection = described_class[:label1, :label2]
-    expect(collection.choices).to eq([choice_1, choice_2])
+    expect(collection).to eq([choice_1, choice_2])
   end
 end


### PR DESCRIPTION
### Describe the change

Hides the guts of `Choices` from the public API

### Why are we doing this?

See https://github.com/piotrmurach/tty-prompt/pull/143/files#r443210835

### Benefits

Underlying guts will be encapsulated from the public

### Drawbacks



### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentation updated?
