### PR TITLE
Add the ability to provide an arbitrary array of values to Prompt::Slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1389,22 +1389,20 @@ If you'd rather not display all possible values in a vertical list, you may cons
 For integers, you can set `:min`(defaults to 0), `:max` and `:step`(defaults to 1) options to configure slider range:
 
 ```ruby
-prompt.slider("Volume", max: 100, step: 5)
+prompt.slider("Volume", min: 0, max: 100, step: 5)
 # =>
 # Volume ──────────●────────── 50
 # (Use ←/→ arrow keys, press Enter to select)
 ```
 
-For strings, you can set `:values` to an array of your desired choices:
+For everything else, you can provide an array of your desired choices:
 
 ```ruby
-prompt.slider("Letter", values: ('a'..'z').to_a)
+prompt.slider("Letter", ('a'..'z').to_a)
 # =>
 # Letter ────────────●───────────── m
 # (Use ←/→ arrow keys, press Enter to select)
 ```
-
-Additionally, you may provide an array of objects, if the objects implement `to_s`.
 
 By default the slider is configured to pick middle of the range as a start value, you can change this by using the `:default` option:
 
@@ -1412,6 +1410,15 @@ By default the slider is configured to pick middle of the range as a start value
 prompt.slider("Volume", max: 100, step: 5, default: 75)
 # =>
 # Volume ───────────────●────── 75
+# (Use ←/→ arrow keys, press Enter to select)
+```
+
+You can also select the default value by name:
+
+```ruby
+prompt.slider("Letter", ('a'..'z').to_a, default: 'q')
+# =>
+# Letter ──────────────────●─────── q
 # (Use ←/→ arrow keys, press Enter to select)
 ```
 
@@ -1472,6 +1479,17 @@ prompt.slider("What size?") do |range|
 end
 # =>
 # Volume |───────────────●──────| 75%
+# (Use ←/→ arrow keys, press Enter to select)
+```
+
+```ruby
+prompt.slider("What letter?") do |range|
+  range.choices ('a'..'z').to_a
+  range.format "|:slider| %s"
+  range.default 'q'
+end
+# =>
+# What letter? |──────────────────●───────| q
 # (Use ←/→ arrow keys, press Enter to select)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1384,9 +1384,9 @@ prompt.suggest("b", possible, indent: 4, single_text: "Perhaps you meant?")
 
 ### 2.10 slider
 
-If you have constrained range of numbers for user to choose from you may consider using `slider`.
+If you'd rather not display all possible values in a vertical list, you may consider using `slider`. The slider provides easy visual way of picking a value marked by `●` symbol.
 
-The slider provides easy visual way of picking a value marked by `●` symbol. You can set `:min`(defaults to 0), `:max` and `:step`(defaults to 1) options to configure slider range:
+For integers, you can set `:min`(defaults to 0), `:max` and `:step`(defaults to 1) options to configure slider range:
 
 ```ruby
 prompt.slider("Volume", max: 100, step: 5)
@@ -1394,6 +1394,17 @@ prompt.slider("Volume", max: 100, step: 5)
 # Volume ──────────●────────── 50
 # (Use ←/→ arrow keys, press Enter to select)
 ```
+
+For strings, you can set `:values` to an array of your desired choices:
+
+```ruby
+prompt.slider("Letter", values: ('a'..'z').to_a)
+# =>
+# Letter ────────────●───────────── m
+# (Use ←/→ arrow keys, press Enter to select)
+```
+
+Additionally, you may provide an array of objects, if the objects implement `to_s`.
 
 By default the slider is configured to pick middle of the range as a start value, you can change this by using the `:default` option:
 

--- a/lib/tty/prompt.rb
+++ b/lib/tty/prompt.rb
@@ -388,16 +388,20 @@ module TTY
     # @example
     #   prompt = TTY::Prompt.new
     #   prompt.slider("What size?", min: 32, max: 54, step: 2)
+    #   prompt.slider("What size?", [ 'xs', 's', 'm', 'l', 'xl' ])
     #
     # @param [String] question
     #   the question to ask
     #
+    # @param [Array] choices
+    #   the choices to display
+    #
     # @return [String]
     #
     # @api public
-    def slider(question, **options, &block)
+    def slider(question, choices = nil, **options, &block)
       slider = Slider.new(self, **options)
-      slider.call(question, &block)
+      slider.call(question, choices, &block)
     end
 
     # Print statement out. If the supplied message ends with a space or

--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -100,7 +100,7 @@ module TTY
 
       # Find a matching choice
       #
-      # @exmaple
+      # @example
       #   choices.find_by(:name, "small")
       #
       # @param [Symbol] attr

--- a/lib/tty/prompt/slider.rb
+++ b/lib/tty/prompt/slider.rb
@@ -9,7 +9,7 @@ module TTY
     class Slider
       HELP = "(Use %s arrow keys, press Enter to select)"
 
-      FORMAT = ":slider %d"
+      FORMAT = ":slider %s"
 
       # Initailize a Slider
       #
@@ -20,6 +20,7 @@ module TTY
       # @option options [Integer] :min The minimum value
       # @option options [Integer] :max The maximum value
       # @option options [Integer] :step The step value
+      # @option options [Array]   :values The values for the slider (instead of calculating them)
       # @option options [String] :format The display format
       #
       # @api public
@@ -29,6 +30,7 @@ module TTY
         @min          = options.fetch(:min) { 0 }
         @max          = options.fetch(:max) { 10 }
         @step         = options.fetch(:step) { 1 }
+        @values       = options.fetch(:values) { nil }
         @default      = options[:default]
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
@@ -96,11 +98,15 @@ module TTY
 
       # Range of numbers to render
       #
-      # @return [Array[Integer]]
+      # @return [Array[Integer, String]]
       #
       # @api private
       def range
-        (@min..@max).step(@step).to_a
+        if @values
+          @values
+        else
+          (@min..@max).step(@step).to_a
+        end
       end
 
       # @api public
@@ -123,6 +129,12 @@ module TTY
         @step = value
       end
 
+      # @api public
+      def values(value)
+        @values = value
+      end
+
+      # @api public
       def format(value)
         @format = value
       end
@@ -208,7 +220,7 @@ module TTY
         @prompt.print(@prompt.clear_lines(lines))
       end
 
-      # @return [Integer]
+      # @return [Integer, String]
       #
       # @api private
       def answer

--- a/lib/tty/prompt/slider.rb
+++ b/lib/tty/prompt/slider.rb
@@ -68,7 +68,7 @@ module TTY
           choices.index(default_choice)
         else
           # default is the index number
-          @default
+          @default - 1
         end
       end
 
@@ -254,7 +254,7 @@ module TTY
       def render_question
         header = ["#{@prefix}#{@question} "]
         if @done
-          header << @prompt.decorate(choices[@active].name.to_s, @active_color)
+          header << @prompt.decorate(choices[@active].to_s, @active_color)
           header << "\n"
         else
           header << render_slider

--- a/lib/tty/prompt/slider.rb
+++ b/lib/tty/prompt/slider.rb
@@ -20,17 +20,16 @@ module TTY
       # @option options [Integer] :min The minimum value
       # @option options [Integer] :max The maximum value
       # @option options [Integer] :step The step value
-      # @option options [Array]   :values The values for the slider (instead of calculating them)
       # @option options [String] :format The display format
       #
       # @api public
       def initialize(prompt, **options)
         @prompt       = prompt
         @prefix       = options.fetch(:prefix) { @prompt.prefix }
+        @choices      = Choices.new
         @min          = options.fetch(:min) { 0 }
         @max          = options.fetch(:max) { 10 }
         @step         = options.fetch(:step) { 1 }
-        @values       = options.fetch(:values) { nil }
         @default      = options[:default]
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
@@ -62,9 +61,14 @@ module TTY
       # @api private
       def initial
         if @default.nil?
-          range.size / 2
+          # no default - choose the middle option
+          choices.size / 2
+        elsif default_choice = choices.find_by(:name, @default)
+          # found a Choice by name - use it
+          choices.index(default_choice)
         else
-          range.index(@default)
+          # default is the index number
+          @default
         end
       end
 
@@ -96,19 +100,6 @@ module TTY
         @show_help = value
       end
 
-      # Range of numbers to render
-      #
-      # @return [Array[Integer, String]]
-      #
-      # @api private
-      def range
-        if @values
-          @values
-        else
-          (@min..@max).step(@step).to_a
-        end
-      end
-
       # @api public
       def default(value)
         @default = value
@@ -129,9 +120,29 @@ module TTY
         @step = value
       end
 
+      # Add a single choice
+      #
       # @api public
-      def values(value)
-        @values = value
+      def choice(*value, &block)
+        if block
+          @choices << (value << block)
+        else
+          @choices << value
+        end
+      end
+
+      # Add multiple choices
+      #
+      # @param [Array[Object]] values
+      #   the values to add as choices
+      #
+      # @api public
+      def choices(values = (not_set = true))
+        if not_set
+          @choices
+        else
+          values.each { |val| @choices << val }
+        end
       end
 
       # @api public
@@ -152,9 +163,17 @@ module TTY
       #   the question to ask
       #
       # @apu public
-      def call(question, &block)
+      def call(question, possibilities = nil, &block)
         @question = question
         block.call(self) if block
+        if possibilities
+          choices(possibilities)
+        end
+
+        # set up a Choices collection for min, max, step
+        # if no possibilities were supplied
+        choices((@min..@max).step(@step).to_a) if @choices.empty?
+
         @active = initial
         @prompt.subscribe(self) do
           render
@@ -167,7 +186,7 @@ module TTY
       alias keydown keyleft
 
       def keyright(*)
-        @active += 1 if (@active + 1) < range.size
+        @active += 1 if (@active + 1) < choices.size
       end
       alias keyup keyright
 
@@ -224,7 +243,7 @@ module TTY
       #
       # @api private
       def answer
-        range[@active]
+        choices[@active].value
       end
 
       # Render question with the slider
@@ -235,7 +254,7 @@ module TTY
       def render_question
         header = ["#{@prefix}#{@question} "]
         if @done
-          header << @prompt.decorate(answer.to_s, @active_color)
+          header << @prompt.decorate(choices[@active].name.to_s, @active_color)
           header << "\n"
         else
           header << render_slider
@@ -256,8 +275,8 @@ module TTY
       def render_slider
         slider = (@symbols[:line] * @active) +
                  @prompt.decorate(@symbols[:bullet], @active_color) +
-                 (@symbols[:line] * (range.size - @active - 1))
-        value = range[@active]
+                 (@symbols[:line] * (choices.size - @active - 1))
+        value = choices[@active].name
         case @format
         when Proc
           @format.call(slider, value)

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -268,14 +268,14 @@ RSpec.describe TTY::Prompt, "#slider" do
     expect(prompt.output.string).to eq(expected_output)
   end
 
-  it "specifies values instead of calculated range" do
+  it "specifies choices instead of calculated range" do
     prompt.on(:keypress) do |event|
       prompt.trigger(:keyright) if event.value == "l"
     end
     prompt.input << "l" << "l" << "\r"
     prompt.input.rewind
 
-    res = prompt.slider("What letter?", values: %w[ a b c d e f g ]) do |range|
+    res = prompt.slider("What letter?", %w[ a b c d e f g ]) do |range|
                           range.default 'b'
                         end
     expect(res).to eq('d')
@@ -303,7 +303,7 @@ RSpec.describe TTY::Prompt, "#slider" do
     expect(prompt.output.string).to eq(expected_output)
   end
 
-  it "specifies values through DSL" do
+  it "specifies choices through DSL" do
     prompt.on(:keypress) do |event|
       prompt.trigger(:keyleft) if event.value == "l"
     end
@@ -312,7 +312,48 @@ RSpec.describe TTY::Prompt, "#slider" do
 
     res = prompt.slider("What letter?") do |range|
                           range.default 'c'
-                          range.values %w[ a b c d e f g ]
+                          range.choices %w[ a b c d e f g ]
+                        end
+    expect(res).to eq('a')
+
+    expected_output = [
+      "\e[?25lWhat letter? ",
+      symbols[:line] * 2,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 4 + " c",
+      "\n\e[90m(Use ←/→ arrow keys, press Enter to select)\e[0m\e[2K\e[1G",
+      "\e[1A\e[2K\e[1G",
+      "What letter? ",
+      symbols[:line] * 1,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 5 + " b",
+      "\e[2K\e[1G",
+      "What letter? ",
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 6 + " a",
+      "\e[2K\e[1G",
+      "What letter? \e[32ma\e[0m\n\e[?25h"
+    ].join
+
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
+  it "specifies choices through DSL" do
+    prompt.on(:keypress) do |event|
+      prompt.trigger(:keyleft) if event.value == "l"
+    end
+    prompt.input << "l" << "l" << "\r"
+    prompt.input.rewind
+
+    res = prompt.slider("What letter?") do |range|
+                          range.default 'c'
+                          range.choice 'a'
+                          range.choice 'b'
+                          range.choice 'c'
+                          range.choice 'd'
+                          range.choice 'e'
+                          range.choice 'f'
+                          range.choice 'g'
                         end
     expect(res).to eq('a')
 

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -267,4 +267,74 @@ RSpec.describe TTY::Prompt, "#slider" do
 
     expect(prompt.output.string).to eq(expected_output)
   end
+
+  it "specifies values instead of calculated range" do
+    prompt.on(:keypress) do |event|
+      prompt.trigger(:keyright) if event.value == "l"
+    end
+    prompt.input << "l" << "l" << "\r"
+    prompt.input.rewind
+
+    res = prompt.slider("What letter?", values: %w[ a b c d e f g ]) do |range|
+                          range.default 'b'
+                        end
+    expect(res).to eq('d')
+
+    expected_output = [
+      "\e[?25lWhat letter? ",
+      symbols[:line] * 1,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 5 + " b",
+      "\n\e[90m(Use ←/→ arrow keys, press Enter to select)\e[0m\e[2K\e[1G",
+      "\e[1A\e[2K\e[1G",
+      "What letter? ",
+      symbols[:line] * 2,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 4 + " c",
+      "\e[2K\e[1G",
+      "What letter? ",
+      symbols[:line] * 3,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 3 + " d",
+      "\e[2K\e[1G",
+      "What letter? \e[32md\e[0m\n\e[?25h"
+    ].join
+
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
+  it "specifies values through DSL" do
+    prompt.on(:keypress) do |event|
+      prompt.trigger(:keyleft) if event.value == "l"
+    end
+    prompt.input << "l" << "l" << "\r"
+    prompt.input.rewind
+
+    res = prompt.slider("What letter?") do |range|
+                          range.default 'c'
+                          range.values %w[ a b c d e f g ]
+                        end
+    expect(res).to eq('a')
+
+    expected_output = [
+      "\e[?25lWhat letter? ",
+      symbols[:line] * 2,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 4 + " c",
+      "\n\e[90m(Use ←/→ arrow keys, press Enter to select)\e[0m\e[2K\e[1G",
+      "\e[1A\e[2K\e[1G",
+      "What letter? ",
+      symbols[:line] * 1,
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 5 + " b",
+      "\e[2K\e[1G",
+      "What letter? ",
+      "\e[32m#{symbols[:bullet]}\e[0m",
+      symbols[:line] * 6 + " a",
+      "\e[2K\e[1G",
+      "What letter? \e[32ma\e[0m\n\e[?25h"
+    ].join
+
+    expect(prompt.output.string).to eq(expected_output)
+  end
 end

--- a/spec/unit/slider_spec.rb
+++ b/spec/unit/slider_spec.rb
@@ -378,4 +378,45 @@ RSpec.describe TTY::Prompt, "#slider" do
 
     expect(prompt.output.string).to eq(expected_output)
   end
+
+  it "sets default choice by name" do
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    res = prompt.slider("What letter?") do |range|
+                          range.default 'a'
+                          range.choice 'a', 1
+                          range.choice 'b', 2
+                          range.choice 'c', 3
+                        end
+
+    expect(res).to eq(1)
+  end
+
+  it "sets default choice by index number" do
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    res = prompt.slider("What letter?") do |range|
+                          range.default 3
+                          range.choice 'a', 1
+                          range.choice 'b', 2
+                          range.choice 'c', 3
+                        end
+
+    expect(res).to eq(3)
+  end
+
+  it "sets choice value to proc and executes it" do
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    res = prompt.slider("What letter?") do |range|
+                          range.choice 'a', 1
+                          range.choice 'b' do "NOT THE BEEEEEEEES!" end
+                          range.choice 'c', 3
+                        end
+
+    expect(res).to eq('NOT THE BEEEEEEEES!')
+  end
 end


### PR DESCRIPTION
Add the ability to provide an arbitrary array of values to Prompt::Slider, overriding the automatic min,max,step calculation.

### Example 
```ruby
require 'tty-prompt'

p = TTY::Prompt.new

apertures = ["f/2.8", "f/3.2", "f/3.5", "f/4", "f/4.5", "f/5", "f/5.6", "f/6.3", "f/7.1", "f/8", "f/9", "f/10", "f/11", "f/13", "f/14", "f/16", "f/18", "f/20", "f/22", "f/25", "f/29", "f/32"]

ans = p.slider( "Select an aperature value.", values: apertures ) do |sl|
  sl.default "f/4"
end

puts ans

class TestObj

  def initialize( name, value )
    @name = name
    @value = value
  end

  attr_reader :name
  attr_reader :value

  def to_s
    @name
  end

end

objs = [ TestObj.new( 'A', 'a' ), TestObj.new( 'B', 'b' ), TestObj.new( 'C', 'c' ) ]

ans = p.slider( "Select an aperature value.", values: objs )

puts ans.value
```

```
Select an aperature value. ───●────────────────── f/4
(Use ←/→ arrow keys, press Enter to select)
Select an aperature value. f/4
f/4
Select an aperature value. ─●─ B
(Use ←/→ arrow keys, press Enter to select)
Select an aperature value. B
b
```

### Describe the change
Allows giving arbitrary/pre-calculated, and String data to a Slider, to be slid through.

### Why are we doing this?
I had a specific need - selecting aperture and shutter speed values - that both included non-numeric values, and were irregularly spaced (so no valid `step` even if I remove the `/`).

### Benefits
I don't see any benefit to limiting Slider to numbers. This adds more capability to the library by supporting arbitrary data, including Objects that define `#to_s`!

### Drawbacks
The only backwards-compatibility issue I can think of would be changing the global `FORMAT` variable to use a string substitution instead of int/digit - but generally, ints translate to strings fine, so it should be okay. If one uses `:min`, `:max`, `:step`, it will still return an Integer.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
