### PR TITLE
add the ability to specify keys to select list items

### DIFF
--- a/README.md
+++ b/README.md
@@ -629,7 +629,30 @@ choices = [
 ]
 ```
 
-You can specify `:key` as an additional option which will be used as short name for selecting the choice via keyboard key press.
+You can specify `:key` as an additional option which will be used as short name for selecting the choice via keyboard key press. When used with `:enum`, the key is displayed instead of a number.
+
+```ruby
+choices = [{name: "small", key: "s"}, {name: "medium", key: "m"}, {name: "large", key: "l"}]
+prompt.select("What size?", choices, enum: ')')
+# =>
+# What size? (Press ↑/↓ arrow to move and Enter to select)
+# ‣ s) small
+#   m) medium
+#   l) large
+```
+
+When providing `:key`, you can override the displayed text with `:key_name` - as in the case of using the escape key:
+
+
+```ruby
+choices = [{name: "next", key: "n"}, {name: "previous", key: "p"}, {name: "exit", key: :escape, key_name: "esc"}]
+prompt.select("Do what?", choices, enum: ')')
+# =>
+# Do what? (Press ↑/↓ arrow to move and Enter to select)
+# ‣ n) next
+#   p) previous
+#   esc) exit
+```
 
 Another way to create menu with choices is using the DSL and the `choice` method. For example, the previous array of choices with hash values can be translated as:
 
@@ -767,6 +790,30 @@ end
 #   2. Kano
 # ‣ 3. Jax
 ```
+
+If your choices include the `:key` and (optionally) `:key_name` settings, those values will be displayed instead of numbers.
+
+```ruby
+choices = [{name: "small", key: "s"}, {name: "medium", key: "m"}, {name: "large", key: "l"}]
+prompt.select("What size?", choices, enum: ')')
+# =>
+# What size? (Press ↑/↓ arrow to move and Enter to select)
+# ‣ s) small
+#   m) medium
+#   l) large
+```
+
+#### 2.6.2.3 `:key_action`
+
+When using `:enum` or Choice `:key` settings, you can change the keypress behavior. By default, `:key_action` is `:move`: pressing a number key or corresponding `:key` will move the cursor to select the choice. You can also use `key_action: :select` to make a keypress immediately select the item.
+
+
+```ruby
+choices = [{name: "small", key: "s"}, {name: "medium", key: "m"}, {name: "large", key: "l"}]
+prompt.select("What size?", choices, enum: ')', key_action: :select)
+```
+
+In the above example, when pressing "l", the "large" option will be immediately selected and the prompt will exit.
 
 #### 2.6.2.3 `:help`
 

--- a/lib/tty/prompt/choice.rb
+++ b/lib/tty/prompt/choice.rb
@@ -67,6 +67,13 @@ module TTY
       # @api public
       attr_reader :key
 
+      # The text to display when this choice is used with :enum (i.e. in List)
+      # Defaults to :key. Use `nil` or `false` to disable showing the enum for
+      # this Choice.
+      #
+      # @api public
+      attr_reader :key_name
+
       # The text to display for disabled choice
       #
       # @api public
@@ -76,9 +83,10 @@ module TTY
       #
       # @api public
       def initialize(name, value, **options)
-        @name  = name
-        @value = value
-        @key   = options[:key]
+        @name     = name
+        @value    = value
+        @key      = options[:key]
+        @key_name = options[:key_name] || @key
         @disabled = options[:disabled].nil? ? false : options[:disabled]
         freeze
       end
@@ -113,7 +121,8 @@ module TTY
         return false unless other.is_a?(self.class)
         name == other.name &&
         value == other.value &&
-        key == other.key
+        key == other.key &&
+        key_name == other.key_name
       end
 
       # Object string representation

--- a/lib/tty/prompt/choices.rb
+++ b/lib/tty/prompt/choices.rb
@@ -14,7 +14,7 @@ module TTY
       extend Forwardable
 
       def_delegators :choices, :length, :size, :to_ary, :empty?,
-                     :values_at, :index, :==
+                     :values_at, :index, :==, :last
 
       # Convenience for creating choices
       #

--- a/spec/unit/choice/eql_spec.rb
+++ b/spec/unit/choice/eql_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe TTY::Prompt::Choice, "#==" do
       not_to eq(described_class.new(:large, 2))
   end
 
+  it "is false with different key attribute" do
+    expect(described_class.new(:large, 1, key: "h")).
+      not_to eq(described_class.new(:large, 1, key: "g"))
+  end
+
+  it "is false with different key_name attribute" do
+    expect(described_class.new(:large, 1, key: "h", key_name: "aych")).
+      not_to eq(described_class.new(:large, 1, key: "h", key_name: "gee"))
+  end
+
   it "is false with non-choice object" do
     expect(described_class.new(:large, 1)).not_to eq(:other)
   end

--- a/spec/unit/choice/from_spec.rb
+++ b/spec/unit/choice/from_spec.rb
@@ -91,11 +91,26 @@ RSpec.describe TTY::Prompt::Choice, "#from" do
   it "creates choice from hash with key property" do
     default = {key: "h", name: "Help", value: :help}
     expected_choice = described_class.new("Help", :help, key: "h")
-    choice = described_class.from(default) 
+    choice = described_class.from(default)
 
     expect(choice).to eq(expected_choice)
     expect(choice.name).to eq("Help")
     expect(choice.value).to eq(:help)
+    expect(choice.key).to eq("h")
+    expect(choice.key_name).to eq("h")
+    expect(choice.disabled?).to eq(false)
+  end
+
+  it "creates choice from hash with key_name property" do
+    default = {key: :escape, key_name: "esc", name: "Help", value: :help}
+    expected_choice = described_class.new("Help", :help, key: :escape, key_name: "esc")
+    choice = described_class.from(default)
+
+    expect(choice).to eq(expected_choice)
+    expect(choice.name).to eq("Help")
+    expect(choice.value).to eq(:help)
+    expect(choice.key).to eq(:escape)
+    expect(choice.key_name).to eq("esc")
     expect(choice.disabled?).to eq(false)
   end
 

--- a/spec/unit/choices/each_spec.rb
+++ b/spec/unit/choices/each_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::Prompt::Choices, ".each" do
+RSpec.describe TTY::Prompt::Choices, "#each" do
   it "iterates over collection" do
     choices = described_class[:large, :medium, :small]
     actual = []

--- a/spec/unit/choices/find_by_spec.rb
+++ b/spec/unit/choices/find_by_spec.rb
@@ -1,10 +1,36 @@
 # frozen_string_literal: true
 
 RSpec.describe TTY::Prompt::Choices, "#find_by" do
-  it "finds a matching choice by key name" do
-    collection = [{name: "large"},{name: "medium"},{name: "small"}]
-    choice = TTY::Prompt::Choice.from(name: "small")
+
+  let( :collection ) {
+    [
+      {name: "large", value: "lg", key: "l", key_name: "L"},
+      {name: "medium", value: "md", key: "m", key_name: "M"},
+      {name: "small", value: "sm", key: "s", key_name: "S"}
+    ]
+  }
+
+  it "finds a matching choice by key :name" do
+    choice = TTY::Prompt::Choice.from(name: "small", value: "sm", key: "s", key_name: "S")
     choices = described_class[*collection]
     expect(choices.find_by(:name, "small")).to eq(choice)
+  end
+
+  it "finds a matching choice by key :value" do
+    choice = TTY::Prompt::Choice.from(name: "medium", value: "md", key: "m", key_name: "M")
+    choices = described_class[*collection]
+    expect(choices.find_by(:value, "md")).to eq(choice)
+  end
+
+  it "finds a matching choice by key :key" do
+    choice = TTY::Prompt::Choice.from(name: "medium", value: "md", key: "m", key_name: "M")
+    choices = described_class[*collection]
+    expect(choices.find_by(:key, "m")).to eq(choice)
+  end
+
+  it "finds a matching choice by key :key_name" do
+    choice = TTY::Prompt::Choice.from(name: "large", value: "lg", key: "l", key_name: "L")
+    choices = described_class[*collection]
+    expect(choices.find_by(:key_name, "L")).to eq(choice)
   end
 end

--- a/spec/unit/choices/last_spec.rb
+++ b/spec/unit/choices/last_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Prompt::Choices, "#last" do
+  it "retuens choice last added to collection" do
+    choices = described_class.new
+    choice_one = TTY::Prompt::Choice.from([:label1, 1])
+    choice_two = TTY::Prompt::Choice.from([:label2, 2])
+
+    choices << [:label1, 1]
+    expect(choices.size).to eq(1)
+    expect(choices.last).to eq(choice_one)
+
+    choices << [:label2, 2]
+    expect(choices.size).to eq(2)
+    expect(choices.last).to eq(choice_two)
+  end
+end

--- a/spec/unit/choices/new_spec.rb
+++ b/spec/unit/choices/new_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe TTY::Prompt::Choices, ".new" do
+RSpec.describe TTY::Prompt::Choices, "#new" do
   it "creates choices collection" do
     choice_1 = TTY::Prompt::Choice.from(:label1)
     choice_2 = TTY::Prompt::Choice.from(:label2)


### PR DESCRIPTION
### Describe the change
This change updates List (Prompt#select) to add the ability to specify keypress
triggers for choices. It makes List respect the already-existing Choice#key, as
well as adding displaying of the keys with :enum, overriding of those displayed
keys with Choice#key_name, and modification of keypress behavior for List. The
default behavior of keypress == move to item is kept, but the ability to have a
keypress immediately select an item was added. This changeset also includes some
whitespace, comment, and spec fixups.


### Why are we doing this?
The readme called out this ability, but it didn't work with List. This adds the ability.

### Benefits
This makes List more robust, especially in 'menu' style uses (i.e. simple keypresses to navigate menus, no arrow keys+enter keys needed)

### Drawbacks
None immediately come to mind. I kept the original default behaviors, so this should be backwards-compatible.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
