### PR TITLE
Add: ability for Prompt#select to auto-select the only available option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-# Change log
+# Change Log
+
+### Added
+* Add the ability to automatically select an option if it's the only one available (Ben Arnold; @seawolf)
 
 ## [v0.23.0] - 2020-12-14
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Or install it yourself as:
       * [2.6.2.5 :per_page](#2625-per_page)
       * [2.6.2.6 :disabled](#2626-disabled)
       * [2.6.2.7 :filter](#2627-filter)
+      * [2.6.2.8 :auto_select](#2628-auto-select)
     * [2.6.3 multi_select](#263-multi_select)
       * [2.6.3.1 :cycle](#2631-cycle)
       * [2.6.3.2 :enum](#2632-enum)
@@ -894,6 +895,24 @@ After the user presses "ka":
 Filter characters can be deleted partially or entirely via, respectively, Backspace and Canc.
 
 If the user changes or deletes a filter, the choices previously selected remain selected.
+
+
+#### 2.6.2.8 `:auto_select`
+
+To automatically select the only available option in a list, use the `:auto_select` option:
+
+```ruby
+meals = [
+  { name: "Fruit", value: 'fruit', disabled: true },
+  { name: "Cake", value: 'cake' },
+  { name: "Nothing", value: 'air', disabled: true },
+]
+nom = prompt.select("What would you like to eat?", meals, auto_select: true)
+puts "Placing your order for #{nom}..."
+# =>
+# What would you like to eat? Cake
+# Placing your order for cake...
+```
 
 ### 2.6.3 multi_select
 

--- a/lib/tty/prompt/list.rb
+++ b/lib/tty/prompt/list.rb
@@ -41,6 +41,7 @@ module TTY
         @enum         = options.fetch(:enum) { nil }
         @default      = Array(options[:default])
         @choices      = Choices.new
+        @auto_select  = options.fetch(:auto_select) { false }
         @active_color = options.fetch(:active_color) { @prompt.active_color }
         @help_color   = options.fetch(:help_color) { @prompt.help_color }
         @cycle        = options.fetch(:cycle) { false }
@@ -451,7 +452,12 @@ module TTY
         until @done
           question = render_question
           @prompt.print(question)
-          @prompt.read_keypress
+
+          if @auto_select && only_one_choice?
+            @done = true
+          else
+            @prompt.read_keypress
+          end
 
           # Split manually; if the second line is blank (when there are no
           # matching lines), it won't be included by using String#lines.
@@ -483,6 +489,13 @@ module TTY
       # @api private
       def answer
         choices[@active - 1].value
+      end
+
+      # Have we only one valid choice available?
+      #
+      # @api private
+      def only_one_choice?
+        choices.enabled.length == 1
       end
 
       # Clear screen lines

--- a/spec/unit/select_spec.rb
+++ b/spec/unit/select_spec.rb
@@ -1068,4 +1068,26 @@ RSpec.describe TTY::Prompt, "#select" do
                        "default index `1` matches disabled choice")
     end
   end
+
+  context "with automatic selection enabled" do
+    it "selects the only available option" do
+      choices = [
+          { name: 'Large', value: :Large, disabled: '(out of stock)' },
+          { name: 'Medium', value: :Medium },
+          { name: 'Small', value: :Small, disabled: '(out of stock)' }
+      ]
+      prompt.input << "\r"
+      prompt.input.rewind
+
+      expect(prompt.select("What size?", choices, auto_select: true)).to eq(:Medium)
+      expect(prompt.output.string).to eq(
+        output_helper(
+          "What size?", choices, "Medium",
+          init: true,
+          hint: "Press #{up_down} arrow to move and Enter to select"
+        ) +
+        exit_message("What size?", "Medium")
+      )
+    end
+  end
 end


### PR DESCRIPTION
### Describe the change

This PR adds the ability for a menu to automatically select the only-available option.

### Why are we doing this?

I am using `TTY::Prompt` in a project that helps the user to build a complicated thing, with as little user input as possible but as much useful output as possible. At various stages, the number of options available can vary between zero and many, depending on previous selections.

Where there is only one option available, I would like to help the user by continuing with that option without them having to confirm the selection of it, while showing what was auto-selected for consistency and future reference.

### Benefits

* Users of `TTY::Prompt` will no longer need to use conditional logic on the number of available choices; instead, they can let the menu handle the situation if so desired

### Drawbacks

* A potential disparity between the various kinds on inputs, unless this feature could be added to the other things provided by `TTY::Prompt`

### Requirements

- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [X] Documentation updated?
- [X] Changelog updated?
