### PR TITLE
Adds a 'none of the above' option to the MultiSelect prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change log
-
+### Added
+* Add the option of a 'clear all' choice to the multi_select prompt by Emanuele Tozzato (@etozzato)
 ## [v0.23.1] - 2021-04-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1152,6 +1152,22 @@ prompt.multi_select("Select drinks?", choices, max: 3)
 #   ⬢ whisky
 # ‣ ⬡ bourbon
 ```
+#### 2.6.3.10 `:reset_choice`
+
+To define a special 'none of the above' choice that will deselect all other choices:
+
+```ruby
+choices = %w(vodka beer wine whisky bourbon none)
+prompt.multi_select("Favourite drinks?", choices, reset_choice: 'none')
+# =>
+# Select drinks? none
+#   ⬡ vodka
+#   ⬡ beer
+#   ⬡ wine
+#   ⬡ whisky
+#   ⬡ bourbon
+# ‣ ⬢ none
+```
 
 ### 2.6.4 enum_select
 

--- a/examples/multi_select_reset_choice.rb
+++ b/examples/multi_select_reset_choice.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "../lib/tty-prompt"
+
+prompt = TTY::Prompt.new
+
+drinks = %w[vodka beer wine whisky bourbon none]
+prompt.multi_select("Choose your favourite drink?", drinks, reset_choice: "none")
+
+genres = {
+  a: "Action games",
+  b: "Arcade games",
+  c: "Fighting games",
+  d: "First-person shooters",
+  e: "Music Games",
+  f: "Party games",
+  g: "Racing games",
+  h: "Role-playing games",
+  i: "Sports games",
+  j: "Strategy games",
+  k: "None of the above"
+}
+
+opts = { max: 3, reset_choice: ["None of the above", :k] }
+prompt.multi_select("Choose your favourite game genres", opts) do |input|
+  genres.each_pair do |key, value|
+    input.choice value, key
+  end
+end

--- a/lib/tty/prompt/multi_list.rb
+++ b/lib/tty/prompt/multi_list.rb
@@ -23,6 +23,7 @@ module TTY
         @echo = options.fetch(:echo, true)
         @min  = options[:min]
         @max  = options[:max]
+        @reset_choice = Choice.from(options[:reset_choice])
       end
 
       # Set a minimum number of choices
@@ -59,6 +60,9 @@ module TTY
         if @selected.include?(active_choice)
           @selected.delete_at(@active - 1)
         else
+          if active_choice == @reset_choice || @selected.include?(@reset_choice)
+            @selected.clear
+          end
           return if @max && @selected.size >= @max
 
           @selected.insert(@active - 1, active_choice)

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -84,6 +84,24 @@ RSpec.describe TTY::Prompt do
     expect(prompt.output.string).to eq(expected_output)
   end
 
+  it "resets all selections when the reset choice is selected" do
+    choices = %w[vodka beer wine whisky bourbon none]
+    prompt.on(:keypress) { |e| prompt.trigger(:keydown) if e.value == "j" }
+    prompt.input << "j" << " " << "j" << " " << "j" << "j" << " " << "j" << " " << "\r"
+
+    prompt.input.rewind
+    expect(prompt.multi_select("Select drinks?", choices, reset_choice: "none")).to eq(["none"])
+  end
+
+  it "ignores an incorrect reset choice" do
+    choices = %w[vodka beer wine whisky bourbon none]
+    prompt.on(:keypress) { |e| prompt.trigger(:keydown) if e.value == "j" }
+    prompt.input << "j" << " " << "j" << " " << "j" << "j" << " " << "j" << " " << "\r"
+
+    prompt.input.rewind
+    expect(prompt.multi_select("Select drinks?", choices, reset_choice: "nope")).to eq(%w[beer wine bourbon none])
+  end
+
   it "selects item when space pressed but doesn't echo item if echo: false" do
     choices = %w[vodka beer wine whisky bourbon]
     prompt.input << " \r"


### PR DESCRIPTION
### Describe the change
When initializing a `multi_select` prompt, accepts a `:reset_choice` parameter. The `reset_choice` will modify the behaviour of the prompt: when selected, all other selections will be deselected.

```ruby
drinks = %w[vodka beer wine whisky bourbon none]
prompt.multi_select("Choose your favourite drink?", drinks, reset_choice: "none")
```

![clear_all](https://user-images.githubusercontent.com/37674/131049199-826aeeb2-30ba-461f-99c8-b51f8c82edcf.gif)
 
### Why are we doing this?
It seems to be a common practice in research to provide a 'none of the above' option rather than submitting an empty multiple-choice form. 

### Benefits
This will make the multi_select prompt move flexible.

### Drawbacks
None, this is an optional parameter.

### Requirements
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
