### PR TITLE
this enables the collector to access the prompt object

### DIFF
--- a/lib/tty/prompt/answers_collector.rb
+++ b/lib/tty/prompt/answers_collector.rb
@@ -3,6 +3,8 @@
 module TTY
   class Prompt
     class AnswersCollector
+      attr_reader :prompt
+
       # Initialize answer collector
       #
       # @api public


### PR DESCRIPTION
### Describe the change
Adds a read-only accessor to the `@prompt` member of `TTY::Prompt::AnswerCollector`

### Why are we doing this?
To prevent ugly compromises in the code when we want to access the prompt without modifying the state of the answer collector.

### Benefits
See above.

### Drawbacks
It's literally one line of code that says `attr_accessor :prompt`.

### Requirements
> <!--- Put an X between brackets on each line if you have done the item: -->
> - [ ] Tests written & passing locally?
> - [ ] Code style checked?
> - [ ] Rebased with `master` branch?
> - [ ] Documentation updated?
> - [ ] Changelog updated?

It's literally one line of code.