### PR TITLE
Change multi_list to allow preserving choice order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [v0.23.2] - 2023-01-11
+
+### Changed
+* Change multi_select to allow preserve user choice ordering
+
 ## [v0.23.1] - 2021-04-17
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Or install it yourself as:
       * [2.6.3.7 :filter](#2637-filter)
       * [2.6.3.8 :min](#2638-min)
       * [2.6.3.9 :max](#2639-max)
+      * [2.6.3.10 :preserve_order](#26310-preserve_order)
     * [2.6.4 enum_select](#264-enum_select)
       * [2.6.4.1 :per_page](#2641-per_page)
       * [2.6.4.1 :disabled](#2641-disabled)
@@ -1146,6 +1147,22 @@ choices = %w(vodka beer wine whisky bourbon)
 prompt.multi_select("Select drinks?", choices, max: 3)
 # =>
 # Select drinks? (max. 3) vodka, beer, whisky
+#   ⬢ vodka
+#   ⬢ beer
+#   ⬡ wine
+#   ⬢ whisky
+# ‣ ⬡ bourbon
+```
+
+#### 2.6.3.10 `:preserve_order`
+
+To preserve the ordering of an user selections, use the `:preserve_order` option:
+
+```ruby
+choices = %w(vodka beer wine whisky bourbon)
+prompt.multi_select("Select drinks?", choices, preserve_order: true)
+# =>
+# Select drinks? (max. 3) beer, vodka, whisky
 #   ⬢ vodka
 #   ⬢ beer
 #   ⬡ wine

--- a/lib/tty/prompt/ordered_selected_choices.rb
+++ b/lib/tty/prompt/ordered_selected_choices.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module TTY
+  class Prompt
+    # @api private
+    class OrderedSelectedChoices
+      include Enumerable
+
+      attr_reader :size
+
+      # Create ordered selected choices
+      #
+      # @param [Array<Choice>] selected
+      # @param [Array<Integer>] indexes (ignored)
+      #
+      # @api public
+      def initialize(selected = [], _indexes = [])
+        @selected = selected
+        @size = @selected.size
+      end
+
+      # Clear ordered selected choices
+      #
+      # @api public
+      def clear
+        @selected.clear
+        @size = 0
+      end
+
+      # Iterate over ordered selected choices
+      #
+      # @api public
+      def each(&block)
+        return to_enum unless block_given?
+
+        @selected.each(&block)
+      end
+
+      # Insert choice at the end
+      #
+      # @param [Integer] index (ignored)
+      # @param [Choice] choice
+      #
+      # @api public
+      def insert(_index, choice)
+        @selected << choice
+        @size += 1
+        self
+      end
+
+      # Delete choice at index
+      #
+      # @return [Choice]
+      #   the deleted choice
+      #
+      # @api public
+      def delete_at(index)
+        return nil if index < 0
+        return nil if index >= @size
+
+        choice = @selected.delete_at(index)
+        @size -= 1
+        choice
+      end
+
+      def find_index_by(&search)
+        (0...@size).bsearch(&search)
+      end
+    end # OrderedSelectedChoices
+  end # Prompt
+end # TTY

--- a/lib/tty/prompt/version.rb
+++ b/lib/tty/prompt/version.rb
@@ -2,6 +2,6 @@
 
 module TTY
   class Prompt
-    VERSION = "0.23.1"
+    VERSION = "0.23.2"
   end # Prompt
 end # TTY

--- a/spec/unit/ordered_selected_choices_spec.rb
+++ b/spec/unit/ordered_selected_choices_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Prompt::OrderedSelectedChoices do
+  it "inserts choices at the end" do
+    choices = %w[A B C D E F]
+    selected = described_class.new
+
+    expect(selected.to_a).to eq([])
+    expect(selected.size).to eq(0)
+
+    selected.insert(5, "F")
+    selected.insert(1, "B")
+    selected.insert(3, "D")
+    selected.insert(0, "A")
+    selected.insert(4, "E")
+    selected.insert(2, "C")
+
+    expect(selected.to_a).to eq(["F", "B", "D", "A", "E", "C"])
+    expect(selected.size).to eq(6)
+
+    expect(selected.delete_at(3)).to eq("A")
+  end
+
+  it "initializes with selected choices" do
+    choices = %w[A B C D E F]
+    selected = described_class.new(choices, (0...choices.size).to_a)
+
+    expect(selected.to_a).to eq(choices)
+    expect(selected.size).to eq(6)
+
+    choice = selected.delete_at(3)
+    expect(choice).to eq("D")
+
+    expect(selected.to_a).to eq(%w[A B C E F])
+    expect(selected.size).to eq(5)
+  end
+
+  it "inserts and deletes choices" do
+    selected = described_class.new
+
+    selected.insert(5, "F")
+    selected.insert(1, "B")
+    selected.insert(3, "D")
+    selected.insert(0, "A")
+
+    expect(selected.to_a).to eq(%w[F B D A])
+    expect(selected.size).to eq(4)
+
+    choice = selected.delete_at(2)
+    expect(choice).to eq("D")
+    expect(selected.to_a).to eq(%w[F B A])
+    expect(selected.size).to eq(3)
+
+    selected.insert(4, "E")
+    choice = selected.delete_at(-999)
+
+    expect(choice).to eq(nil)
+    expect(selected.to_a).to eq(%w[F B A E])
+    expect(selected.size).to eq(4)
+  end
+
+  it "clears choices" do
+    selected = described_class.new(%w[B D F])
+
+    expect(selected.to_a).to eq(%w[B D F])
+    expect(selected.size).to eq(3)
+
+    selected.clear
+
+    expect(selected.to_a).to eq([])
+    expect(selected.size).to eq(0)
+  end
+end


### PR DESCRIPTION
### Describe the change
This Pull Request allows the multi_select to preserve user choice ordering.

### Why are we doing this?
In some use cases, the user wants to trigger actions based on selection in a specific order.

### Benefits
The library allows to preserve the user ordering when using a specific option `preserve_order`.

### Drawbacks
I do not see drawbacks as the initial behaviour is kept.

### Requirements
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
