### PR TITLE
Commands for prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change log
 
+## [v0.24.0] - 2023-02-02
+* Add Command List type of input
+
 ## [v0.23.1] - 2021-04-17
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 
 # gem "tty-reader", git: "https://github.com/piotrmurach/tty-reader"
 # gem "pastel", git: "https://github.com/piotrmurach/pastel"
+gem 'algorithms', '~> 0.6.1'
 gem "json", "2.4.1" if RUBY_VERSION == "2.0.0"
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Or install it yourself as:
     * [2.11.2 warn](#2112-warn)
     * [2.11.3 error](#2113-error)
   * [2.12 keyboard events](#212-keyboard-events)
+  * [2.13 commands](#213-commands)
 * [3. settings](#3-settings)
   * [3.1 :symbols](#31-symbols)
   * [3.2 :active_color](#32-active_color)
@@ -1539,7 +1540,7 @@ Print message(s) in green do:
 prompt.ok(...)
 ```
 
-#### 2.12.2 warn
+#### 2.11.2 warn
 
 Print message(s) in yellow do:
 
@@ -1606,6 +1607,32 @@ The available events are:
 * `:keyescape`
 * `:keydelete`
 * `:keybackspace`
+
+### 2.13 Commands
+
+To show a command and the associated arguments in a list as the user enters keys into the input.
+
+```ruby
+prompt.command(">", { "read" => ["key"] })
+# =>
+# >
+# read key
+```
+
+Commands are a pairing of a string for the command name and an array of arguments for the command.
+
+If you only want a few commands to be displayed while typing you can use `num_commands_shown`.
+
+```ruby
+commands = {
+  "read" => ["key"],
+  "write" => ["key", "value"]
+}
+prompt.command(">", commands, num_commands_shown: 1)
+# =>
+# > wr
+# write key value
+```
 
 ## 3 settings
 

--- a/examples/command_list.rb
+++ b/examples/command_list.rb
@@ -2,14 +2,12 @@
 
 require_relative "../lib/tty-prompt"
 
-prompt = TTY::Prompt.new
+prompt = TTY::Prompt.new(track_history: true)
 
-commands = [
-  {
-    "read" => value: ["key"],
-    "write" => value: ["key", "value"]
-  }
-]
+commands = {
+  "read" => ["key"],
+  "write" => ["key", "value"]
+}
 
 answer = prompt.command(">", commands)
 

--- a/examples/command_list.rb
+++ b/examples/command_list.rb
@@ -10,5 +10,6 @@ commands = {
 }
 
 answer = prompt.command(">", commands)
+answer = prompt.command(">", commands)
 
 puts answer.inspect

--- a/examples/command_list.rb
+++ b/examples/command_list.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require_relative "../lib/tty-prompt"
+
+prompt = TTY::Prompt.new
+
+commands = [
+  {
+    "read" => value: ["key"],
+    "write" => value: ["key", "value"]
+  }
+]
+
+answer = prompt.command(">", commands)
+
+puts answer.inspect

--- a/lib/tty/prompt.rb
+++ b/lib/tty/prompt.rb
@@ -7,6 +7,7 @@ require "tty-reader"
 require "tty-screen"
 
 require_relative "prompt/answers_collector"
+require_relative "prompt/command_list"
 require_relative "prompt/confirm_question"
 require_relative "prompt/errors"
 require_relative "prompt/expander"
@@ -534,6 +535,11 @@ module TTY
     def collect(**options, &block)
       collector = AnswersCollector.new(self, **options)
       collector.call(&block)
+    end
+
+    def command(message, commands = {}, **options, &block)
+      command = CommandList.new(self, **options)
+      command.call(message, commands, &block)
     end
 
     # Check if outputing to terminal

--- a/lib/tty/prompt/command_list.rb
+++ b/lib/tty/prompt/command_list.rb
@@ -68,6 +68,7 @@ module TTY
         @prompt.subscribe(self) do
           render
         end
+        @prompt.reader.add_to_history(@current_command)
         @current_command
       end
 
@@ -92,6 +93,21 @@ module TTY
       # @api public
       def keybackspace(*)
         @current_command = @current_command.chop
+      end
+
+      # Respond to key tab event
+      def keytab(*)
+        @current_command = @current_displayed_commands.first if @current_displayed_commands.size > 0
+      end
+
+      # Respond to key up event
+      def keyup(*)
+        @current_command = @prompt.reader.history_previous if @prompt.reader.history_previous?
+      end
+
+      # Respond to key down event
+      def keydown(*)
+        @current_command = @prompt.reader.history_next if @prompt.reader.history_next?
       end
 
       private

--- a/lib/tty/prompt/command_list.rb
+++ b/lib/tty/prompt/command_list.rb
@@ -107,7 +107,11 @@ module TTY
 
       # Respond to key down event
       def keydown(*)
-        @current_command = @prompt.reader.history_next if @prompt.reader.history_next?
+        if @prompt.reader.history_next?
+          @current_command = @prompt.reader.history_next
+        else
+          @current_command = ''
+        end
       end
 
       private

--- a/lib/tty/prompt/command_list.rb
+++ b/lib/tty/prompt/command_list.rb
@@ -83,7 +83,7 @@ module TTY
       #
       # @api public
       def keypress(event)
-        return unless event.key.name == :alpha || event.key.name == :space
+        return unless event.key.name == :alpha || event.key.name == :space || event.key.name == :num
         @current_command += event.value
       end
 
@@ -108,7 +108,7 @@ module TTY
           @prompt.print(refresh)
         end
 
-        @prompt.print(@prompt.clear_line + @current_command + "\n")
+        @prompt.print(@prompt.clear_line + render_header + "\n")
       end
 
       # Render the header

--- a/lib/tty/prompt/command_list.rb
+++ b/lib/tty/prompt/command_list.rb
@@ -84,7 +84,7 @@ module TTY
       #
       # @api public
       def keypress(event)
-        return unless event.key.name == :alpha || event.key.name == :space || event.key.name == :num
+        return unless event.key.name == :alpha || event.key.name == :space || event.key.name == :num || event.key.name == :ignore
         @current_command += event.value
       end
 

--- a/lib/tty/prompt/command_list.rb
+++ b/lib/tty/prompt/command_list.rb
@@ -1,0 +1,163 @@
+# frozen_string_literal: true
+
+require 'algorithms'
+
+module TTY
+  class Prompt
+    # A prompt responsible for inputting commands with help text
+    #
+    # @api private
+    class CommandList
+      # Create instance of CommandList
+      #
+      # @api public
+      def initialize(prompt, options = {})
+        @prompt = prompt
+        @commands = Containers::Trie.new()
+        @current_displayed_commands = []
+        @done = false
+        @max_command_len = 0
+        @current_command = ''
+
+        @num_commands_shown  = options.fetch(:num_commands_shown, 5)
+        @prefix             = options.fetch(:prefix) { @prompt.prefix }
+        @help_color         = options.fetch(:help_color) { @prompt.help_color }
+        @quiet              = options.fetch(:quiet) { @prompt.quiet }
+      end
+
+      # Add a command to the list
+      #
+      # @api public
+      def command(name, arguments)
+        if name.length > @max_command_len
+          @max_command_len = name.length
+        end
+        @commands.push(name, arguments)
+      end
+
+      # Add multiple commands to the list
+      #
+      # @api public
+      def commands(commands)
+        commands.each do |command, arguments|
+          command(command, arguments)
+        end
+      end
+
+      # Set quiet mode.
+      #
+      # @api public
+      def quiet(value)
+        @quiet = value
+      end
+
+      # Set number of commands shown.
+      #
+      # @api public
+      def num_commands_shown(value)
+        @num_commands_shown = value
+      end
+
+      # Execute this prompt
+      #
+      # @api public
+      def call(message, commands, &block)
+        commands(commands)
+        @message = message
+        block.call(self) if block
+        @prompt.subscribe(self) do
+          render
+        end
+        @current_command
+      end
+
+      # Respond to submit event
+      #
+      # @api public
+      def keyenter(*)
+        @done = true
+      end
+      alias keyreturn keyenter
+
+      # Respond to key press event
+      #
+      # @api public
+      def keypress(event)
+        return unless event.key.name == :alpha || event.key.name == :space
+        @current_command += event.value
+      end
+
+      # Respond to key backspace event
+      #
+      # @api public
+      def keybackspace(*)
+        @current_command = @current_command.chop
+      end
+
+      private
+
+      # @api private
+      def render
+        until @done
+          @prompt.print(render_header)
+          commands = render_commands
+          if commands && !@quiet
+            @prompt.print("\n" + commands)
+          end
+          @prompt.read_keypress
+          @prompt.print(refresh)
+        end
+
+        @prompt.print(@prompt.clear_line + @current_command + "\n")
+      end
+
+      # Render the header
+      #
+      # @return [String]
+      #
+      # @api private
+      def render_header
+        @prefix + @message + @current_command
+      end
+
+      # Render the commands
+      #
+      # @return [nil, String]
+      #
+      # @api private
+      def render_commands
+        command_wildcard = @current_command + ('*' * [@max_command_len - @current_command.size, 0].max)[0..@max_command_len]
+        possible_commands = @commands.wildcard(command_wildcard) || []
+        @current_displayed_commands = possible_commands[0...@num_commands_shown]
+        command_render = if @current_displayed_commands.empty?
+          return nil
+        else
+          commands_and_args = ""
+          @current_displayed_commands.each do |command|
+            args = @commands[command]
+            commands_and_args += "#{command} #{args.join(" ")}\n"
+          end
+          commands_and_args
+        end
+        @prompt.decorate(command_render +
+            @prompt.cursor.up(@current_displayed_commands.size + 1) +
+            @prompt.cursor.column(0) +
+            @prompt.cursor.forward(render_header.size),
+          @help_color)
+      end
+
+      # Refresh the current input
+      #
+      # @return [String]
+      #
+      # @api private
+      def refresh
+        clear = unless @current_displayed_commands.empty?
+          @prompt.clear_lines(@current_displayed_commands.size + 1, :down) +
+            @prompt.cursor.up(@current_displayed_commands.size)
+        end
+        (clear || "") + @prompt.clear_line
+      end
+    end
+  end
+end

--- a/spec/unit/command_list_spec.rb
+++ b/spec/unit/command_list_spec.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+RSpec.describe TTY::Prompt::CommandList do
+  subject(:prompt) { TTY::Prompt::Test.new }
+  before { allow(TTY::Screen).to receive(:width).and_return(200) }
+
+  it "returns nothing when no commands are entered" do
+    commands = {
+      "read" => ["key"],
+      "write" => ["key", "value"]
+    }
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    expected_output = []
+    expected_output << ">\n\e[90mread key\nwrite key value\n\e[3A\e[0G\e[1C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1B"
+    expected_output << "\e[2K\e[1G\e[2A\e[2K\e[1G\e[2K\e[1G\n"
+    expect(prompt.command(">", commands)).to eq('')
+    expect(prompt.output.string).to eq(expected_output.join)
+  end
+
+  it "returns input entered and filters commands" do
+    commands = {
+      "read" => ["key"],
+      "write" => ["key", "value"]
+    }
+
+    input = "r"
+    prompt.input << "#{input}\r"
+    prompt.input.rewind
+
+    expect(prompt.command(">", commands)).to eq(input)
+    expected_output = []
+    expected_output << ">\n\e[90mread key\nwrite key value\n\e[3A\e[0G\e[1C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1B"
+    expected_output << "\e[2K\e[1G\e[2A\e[2K\e[1G"
+    expected_output << ">r\n\e[90mread key\n\e[2A\e[0G\e[2C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1A\e[2K\e[1G\e[2K\e[1Gr\n"
+    expect(prompt.output.string).to eq(expected_output.join)
+  end
+
+  it "does not output commands when quiet" do
+    commands = {
+      "read" => ["key"],
+      "write" => ["key", "value"]
+    }
+
+    input = "r"
+    prompt.input << "#{input}\r"
+    prompt.input.rewind
+
+    expect(prompt.command(">", commands, quiet: true)).to eq(input)
+    expected_output = []
+    expected_output << ">\e[2K\e[1G\e[1B\e[2K\e[1G\e[1B\e[2K\e[1G\e[2A\e[2K\e[1G"
+    expected_output<< ">r\e[2K\e[1G\e[1B\e[2K\e[1G\e[1A\e[2K\e[1G\e[2K\e[1Gr\n"
+    expect(prompt.output.string).to eq(expected_output.join)
+  end
+
+  it "limits the number of commands shown" do
+    commands = {
+      "read" => ["key"],
+      "write" => ["key", "value"]
+    }
+
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    expect(prompt.command(">", commands, { num_commands_shown: 1 })).to eq("")
+    expected_output = ">\n\e[90mread key\n\e[2A\e[0G\e[1C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1A\e[2K\e[1G\e[2K\e[1G\n"
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
+  it "removes current input with backspace" do
+    commands = {
+      "read" => ["key"],
+    }
+
+    # Makes a == backspace key press
+    prompt.on(:keypress) { |e| prompt.trigger(:keybackspace) if e.value == "a" }
+    prompt.input << "ra\r"
+    prompt.input.rewind
+
+    expect(prompt.command(">", commands)).to eq("a")
+    expected_output = []
+    expected_output << ">\n\e[90mread key\n\e[2A\e[0G\e[1C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1A\e[2K\e[1G"
+    expected_output << ">r\n\e[90mread key\n\e[2A\e[0G\e[2C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1A\e[2K\e[1G"
+    expected_output << ">a\e[2K\e[1G\e[2K\e[1Ga\n"
+    expect(prompt.output.string).to eq(expected_output.join)
+  end
+
+  it "allows a block to add commands" do
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    result = prompt.command(">") do |cmd|
+      cmd.command "read", ["key"]
+    end
+
+    expect(result).to eq("")
+    expected_output = ">\n\e[90mread key\n\e[2A\e[0G\e[1C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1A\e[2K\e[1G\e[2K\e[1G\n"
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
+  it "sets num commands shown from the block" do
+    commands = {
+      "read" => ["key"],
+      "write" => ["key", "value"]
+    }
+
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    result = prompt.command(">") do |cmd|
+      cmd.num_commands_shown(1)
+      cmd.commands(commands)
+    end
+
+    expect(result).to eq("")
+    expected_output = ">\n\e[90mread key\n\e[2A\e[0G\e[1C\e[0m\e[2K\e[1G\e[1B\e[2K\e[1G\e[1A\e[2K\e[1G\e[2K\e[1G\n"
+    expect(prompt.output.string).to eq(expected_output)
+  end
+
+  it "sets quiet from the block" do
+    commands = {
+      "read" => ["key"],
+      "write" => ["key", "value"]
+    }
+
+    prompt.input << "\r"
+    prompt.input.rewind
+
+    result = prompt.command(">") do |cmd|
+      cmd.quiet(true)
+      cmd.commands(commands)
+    end
+
+    expect(result).to eq("")
+    expected_output = ">\e[2K\e[1G\e[1B\e[2K\e[1G\e[1B\e[2K\e[1G\e[2A\e[2K\e[1G\e[2K\e[1G\n"
+    expect(prompt.output.string).to eq(expected_output)
+  end
+end

--- a/tty-prompt.gemspec
+++ b/tty-prompt.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.0.0"
 
+  spec.add_dependency "algorithms", "~> 0.6.1"
   spec.add_dependency "pastel",     "~> 0.8"
   spec.add_dependency "tty-reader", "~> 0.8"
 


### PR DESCRIPTION
### Describe the change
This PR adds in an entirely new type to the prompt - commands.

This fulfills the ability to have an interactive shell where the user is able to input items and the console shows possible commands that they can run given the currently entered characters.

https://github.com/piotrmurach/tty-prompt/assets/5913106/738e7cfc-e945-45c4-8e31-3bacf0b746b0

### Why are we doing this? / Benefits
This acts very similar to a single line input, but it provides hints toward what you should enter. I couldn't find a good way to do this with the current implementation so I decided to add my own. I think this is very useful in command like systems where you have a choice, but that choice also has optional or different post-fix than the selection we are actually using.

In the future I could see adding support for things like optional arguments, or different ways to color/display.

### Drawbacks
Adds another system to support, the single-line input basically does this except without the suggestions, it's not a new type of input, just a new type of suggestions. Could possibly be added to single-line input instead.

### Requirements
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
