### PR TITLE
Set Prompt#messages to default on Questions initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## master
+
+### Fixed
+* Fix Prompt#ask not having custom messages set from key arguments
+
 ## [v0.23.1] - 2021-04-17
 
 ### Changed

--- a/lib/tty/prompt.rb
+++ b/lib/tty/prompt.rb
@@ -176,7 +176,7 @@ module TTY
     #
     # @api public
     def invoke_question(object, message, **options, &block)
-      options[:messages] = self.class.messages
+      options[:messages] = self.class.messages.merge(options[:messages] || {})
       question = object.new(self, **options)
       question.(message, &block)
     end

--- a/spec/unit/question/validate_spec.rb
+++ b/spec/unit/question/validate_spec.rb
@@ -87,6 +87,29 @@ RSpec.describe TTY::Prompt::Question, "#validate" do
     ].join)
   end
 
+  let(:expected_custom_validation_message) { [
+    "What is your email? ",
+    "\e[2K\e[1GWhat is your email? w",
+    "\e[2K\e[1GWhat is your email? wr",
+    "\e[2K\e[1GWhat is your email? wro",
+    "\e[2K\e[1GWhat is your email? wron",
+    "\e[2K\e[1GWhat is your email? wrong",
+    "\e[2K\e[1GWhat is your email? wrong\n",
+    "\e[31m>>\e[0m Not an email!\e[1A",
+    "\e[2K\e[1G",
+    "What is your email? ",
+    "\e[2K\e[1GWhat is your email? p",
+    "\e[2K\e[1GWhat is your email? p@",
+    "\e[2K\e[1GWhat is your email? p@m",
+    "\e[2K\e[1GWhat is your email? p@m.",
+    "\e[2K\e[1GWhat is your email? p@m.c",
+    "\e[2K\e[1GWhat is your email? p@m.co",
+    "\e[2K\e[1GWhat is your email? p@m.com",
+    "\e[2K\e[1G",
+    "\e[1A\e[2K\e[1G",
+    "What is your email? \e[32mp@m.com\e[0m\n"
+  ].join }
+
   it "provides custom error message for wrong input" do
     prompt.input << "wrong\np@m.com"
     prompt.input.rewind
@@ -96,14 +119,36 @@ RSpec.describe TTY::Prompt::Question, "#validate" do
     end
 
     expect(answer).to eq("p@m.com")
+    expect(prompt.output.string).to eq(expected_custom_validation_message)
+  end
+
+  it "provides custom error message for wrong input by keyword parameter instead of passing by block" do
+    prompt.input << "wrong\np@m.com"
+    prompt.input.rewind
+
+    answer = prompt.ask("What is your email?", validate: :email,
+                        messages: { valid?: 'Not an email!' })
+
+    expect(answer).to eq("p@m.com")
+    expect(prompt.output.string).to eq(expected_custom_validation_message)
+  end
+
+  it "keeps the default messages after adding only one custom message" do
+    prompt.input << "\np\np@m.com"
+    prompt.input.rewind
+
+    answer = prompt.ask("What is your email?", required: true, validate: :email,
+                        messages: { valid?: 'Not an email!' })
+
+    expect(answer).to eq("p@m.com")
     expect(prompt.output.string).to eq([
       "What is your email? ",
-      "\e[2K\e[1GWhat is your email? w",
-      "\e[2K\e[1GWhat is your email? wr",
-      "\e[2K\e[1GWhat is your email? wro",
-      "\e[2K\e[1GWhat is your email? wron",
-      "\e[2K\e[1GWhat is your email? wrong",
-      "\e[2K\e[1GWhat is your email? wrong\n",
+      "\e[2K\e[1GWhat is your email? \n",
+      "\e[31m>>\e[0m Value must be provided\e[1A",
+      "\e[2K\e[1G",
+      "What is your email? ",
+      "\e[2K\e[1GWhat is your email? p",
+      "\e[2K\e[1GWhat is your email? p\n",
       "\e[31m>>\e[0m Not an email!\e[1A",
       "\e[2K\e[1G",
       "What is your email? ",


### PR DESCRIPTION
### Describe the change
What does this Pull Request do?

The PR address the bug from the issue https://github.com/piotrmurach/tty-prompt/issues/197

### Why are we doing this?
Any related context as to why is this is a desirable change.

To fix the bug of not being able to define custom messages from key arguments

### Benefits
How will the library improve?

Fix the issue of not being able to define custom messages from key arguments, (previously was working only be block usage)

### Drawbacks
Possible drawbacks applying this change.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
