### PR TITLE
Fix off by one with default value in pagination

### DIFF
--- a/lib/tty/prompt/paginator.rb
+++ b/lib/tty/prompt/paginator.rb
@@ -21,7 +21,7 @@ module TTY
       #
       # @api private
       def initialize(**options)
-        @last_index  = Array(options[:default]).flatten.first || 0
+        @last_index  = Array(options[:default]).flatten.first
         @per_page    = options[:per_page]
         @start_index = Array(options[:default]).flatten.first
       end
@@ -75,15 +75,23 @@ module TTY
           end
         end
 
-        step = (current_index - @last_index).abs
-        if current_index > @last_index # going up
-          if current_index >= @end_index && current_index < list.size - 1
-            last_page = list.size - @per_page
-            @start_index = [@start_index + step, last_page].min
+        if @last_index.nil?
+          if current_index == @start_index && current_index > 0
+            @start_index -= 1
+          elsif current_index == @end_index && current_index < list.size - 1
+            @start_index += 1
           end
-        elsif current_index < @last_index # going down
-          if current_index <= @start_index && current_index > 0
-            @start_index = [@start_index - step, 0].max
+        else
+          step = (current_index - @last_index).abs
+          if current_index > @last_index # going up
+            if current_index >= @end_index && current_index < list.size - 1
+              last_page = list.size - @per_page
+              @start_index = [@start_index + step, last_page].min
+            end
+          elsif current_index < @last_index # going down
+            if current_index <= @start_index && current_index > 0
+              @start_index = [@start_index - step, 0].max
+            end
           end
         end
 

--- a/spec/unit/multi_select_spec.rb
+++ b/spec/unit/multi_select_spec.rb
@@ -380,7 +380,7 @@ RSpec.describe TTY::Prompt do
       expect(answer).to eq(["D"])
 
       expected_output =
-        output_helper("What letter?", choices[3..5], "D", %w[D], init: true,
+        output_helper("What letter?", choices[2..4], "D", %w[D], init: true,
           hint: "Press #{up_down}/#{left_right} arrow to move, Space/Ctrl+A|R to select (all|rev) and Enter to finish") +
         exit_message("What letter?", %w[D])
 
@@ -396,7 +396,7 @@ RSpec.describe TTY::Prompt do
       expect(answer).to eq([4])
 
       expected_output =
-        output_helper("What letter?", choices.keys[3..5], :D, [:D], init: true,
+        output_helper("What letter?", choices.keys[2..4], :D, [:D], init: true,
           hint: "Press #{up_down}/#{left_right} arrow to move, Space/Ctrl+A|R to select (all|rev) and Enter to finish") +
         exit_message("What letter?", %w[D])
 
@@ -416,7 +416,7 @@ RSpec.describe TTY::Prompt do
       expect(answer).to eq(["D"])
 
       expected_output =
-        output_helper("What letter?", choices[3..5], "D", %w[D], init: true,
+        output_helper("What letter?", choices[2..4], "D", %w[D], init: true,
           hint: "Press #{up_down}/#{left_right} arrow to move, Space/Ctrl+A|R to select (all|rev) and Enter to finish") +
         exit_message("What letter?", %w[D])
 
@@ -472,7 +472,7 @@ RSpec.describe TTY::Prompt do
       expect(answer).to eq(%w[4 10])
 
       expected_output =
-        output_helper("What number?", choices[3..6], "4", ["4"], init: true,
+        output_helper("What number?", choices[1..4], "4", ["4"], init: true,
           hint: "Press #{up_down}/#{left_right} arrow to move, Space/Ctrl+A|R to select (all|rev) and Enter to finish") +
         output_helper("What number?", choices[4..7], "8", ["4"]) +
         output_helper("What number?", choices[8..9], "10", ["4"]) +

--- a/spec/unit/paginator_spec.rb
+++ b/spec/unit/paginator_spec.rb
@@ -75,6 +75,15 @@ RSpec.describe TTY::Prompt::Paginator, "#paginate" do
     expect(paginator.end_index).to eq(6)
   end
 
+  it "always returns a page that includes the current selection" do
+    list = (1..100).to_a
+    list.each do |one_based_index|
+      zero_based_page_indexes = described_class.new.paginate(list, one_based_index, 5).map(&:last)
+      zero_based_index = one_based_index - 1
+      expect(zero_based_page_indexes).to include(zero_based_index)
+    end
+  end
+
   it "starts with default selection" do
     list = %w[a b c d e f g]
     paginator = described_class.new(per_page: 3, default: 3)

--- a/spec/unit/select_spec.rb
+++ b/spec/unit/select_spec.rb
@@ -394,9 +394,9 @@ RSpec.describe TTY::Prompt, "#select" do
       expect(answer).to eq("D")
       expected_output = [
         "\e[?25lWhat letter? \e[90m(Press #{up_down}/#{left_right} arrow to move and Enter to select)\e[0m\n",
+        "  C\n",
         "\e[32m#{symbols[:marker]} D\e[0m\n",
-        "  E\n",
-        "  F",
+        "  E",
         "\e[2K\e[1G\e[1A" * 3,
         "\e[2K\e[1G",
         "What letter? \e[32mD\e[0m\n\e[?25h"
@@ -416,9 +416,9 @@ RSpec.describe TTY::Prompt, "#select" do
       expect(answer).to eq(4)
       expected_output = [
         "\e[?25lWhat letter? \e[90m(Press #{up_down}/#{left_right} arrow to move and Enter to select)\e[0m\n",
+        "  C\n",
         "\e[32m#{symbols[:marker]} D\e[0m\n",
-        "  E\n",
-        "  F",
+        "  E",
         "\e[2K\e[1G\e[1A" * 3,
         "\e[2K\e[1G",
         "What letter? \e[32mD\e[0m\n\e[?25h"
@@ -441,9 +441,9 @@ RSpec.describe TTY::Prompt, "#select" do
 
       expected_output = [
         "\e[?25lWhat letter? \e[90m(Press #{up_down}/#{left_right} arrow to move and Enter to select)\e[0m\n",
+        "  C\n",
         "\e[32m#{symbols[:marker]} D\e[0m\n",
-        "  E\n",
-        "  F",
+        "  E",
         "\e[2K\e[1G\e[1A" * 3,
         "\e[2K\e[1G",
         "What letter? \e[32mD\e[0m\n\e[?25h"
@@ -484,7 +484,7 @@ RSpec.describe TTY::Prompt, "#select" do
       expect(answer).to eq("10")
 
       expected_output = [
-        output_helper("What number?", choices[3..6], "4", init: true,
+        output_helper("What number?", choices[1..4], "4", init: true,
           hint: "Press #{up_down}/#{left_right} arrow to move and Enter to select"),
         output_helper("What number?", choices[4..7], "8"),
         output_helper("What number?", choices[8..9], "10"),


### PR DESCRIPTION
### Describe the change
What does this Pull Request do?

This updates the logic to make sure that the default select value is visible on the page when using `TTY::Prompt#select` with `default:` set.

### Why are we doing this?
Any related context as to why is this is a desirable change.

This fixes the bug outlined in #206.

### Benefits
How will the library improve?

It changes the way that the default value is displayed from before to match the way that we scroll through values in the selector. Basically the default value will never be at the top or bottom of the visible options unless it is the first or last value of the entire list. Before it was possible for a value to appear at the top and when it would have been at the bottom it sometimes caused this bug.

![ezgif-3-38f5270441](https://github.com/user-attachments/assets/53938ef8-b76e-4b40-baec-303c4ccc9194)

### Drawbacks
Possible drawbacks applying this change.

None that I can think of.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [ ] Code style checked?
- [ ] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
